### PR TITLE
Add parallax cleanup on unmount

### DIFF
--- a/src/app/ClientBody.tsx
+++ b/src/app/ClientBody.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect } from "react";
-import { initScrollAnimations, initParallaxEffect } from '../lib/animate';
+import { initScrollAnimations, initParallaxEffect } from "../lib/animate";
 
 export default function ClientBody({
   children,
@@ -14,6 +14,10 @@ export default function ClientBody({
     document.body.className = "antialiased font-inter bg-background";
     initScrollAnimations();
     const cleanupParallax = initParallaxEffect();
+
+    return () => {
+      if (cleanupParallax) cleanupParallax();
+    };
   }, []);
 
   return <div className="antialiased font-inter">{children}</div>;


### PR DESCRIPTION
## Summary
- clean up parallax scroll listener when ClientBody unmounts

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b041918234832587ec3234dd8cd7be