### PR TITLE
feat: add animated scroll and parallax sections

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -8,6 +8,7 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "framer-motion": "^12.23.12",
+        "gsap": "^3.12.5",
         "lucide-react": "^0.542.0",
         "next": "^15.3.2",
         "react": "^18.3.1",
@@ -480,6 +481,8 @@
     "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
 
     "graphemer": ["graphemer@1.4.0", "", {}, "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag=="],
+
+    "gsap": ["gsap@3.13.0", "", {}, "sha512-QL7MJ2WMjm1PHWsoFrAQH/J8wUeqZvMtHO58qdekHpCfhvhSL4gSiz6vJf5EeMP0LOn3ZCprL2ki/gjED8ghVw=="],
 
     "has-bigints": ["has-bigints@1.1.0", "", {}, "sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg=="],
 

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "framer-motion": "^12.23.12",
+    "gsap": "^3.12.5",
     "lucide-react": "^0.542.0",
     "next": "^15.3.2",
     "react": "^18.3.1",

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,7 @@
 import Image from "next/image";
 import Link from "next/link";
 import MainLayout from "@/components/layout/MainLayout";
+import AnimatedSection from "@/components/AnimatedSection";
 
 export default function Home() {
   const latestProducts = [
@@ -92,7 +93,7 @@ export default function Home() {
     <MainLayout transparentHeader={true}>
       {/* Hero Section */}
       <section className="relative w-full h-screen bg-black text-white overflow-hidden">
-        <div className="absolute inset-0 z-0">
+        <AnimatedSection speed={0.3} className="absolute inset-0 z-0">
           <Image
             src="https://ext.same-assets.com/1118492138/3414069527.jpeg"
             alt="Фоновая текстура кожи"
@@ -101,71 +102,75 @@ export default function Home() {
             priority
             className="animate-ken-burns"
           />
-        </div>
+        </AnimatedSection>
 
         {/* Hero Content */}
         <div className="relative z-10 px-8 pt-40 h-full flex flex-col justify-between pb-32">
-          <div className="animate-fade-in">
-            <h1 className="text-6xl sm:text-7xl lg:text-8xl font-bold mb-2 animate-reveal">
+          <AnimatedSection>
+            <h1 className="text-6xl sm:text-7xl lg:text-8xl font-bold mb-2">
               Ускоряйтесь <br />
               <span className="inline-block mt-2">вперёд.</span>
             </h1>
             <div className="mt-8 max-w-xl">
-              <p className="text-xl sm:text-2xl font-medium animate-reveal-delay">
+              <p className="text-xl sm:text-2xl font-medium">
                 Ваш партнёр по кожевенному
                 <br />
                 производству, ориентированный на будущее.
               </p>
             </div>
-          </div>
+          </AnimatedSection>
 
           {/* Navigation Cards */}
           <div className="w-full max-w-6xl mx-auto">
             <div className="grid grid-cols-1 md:grid-cols-2 gap-4 md:gap-8">
-              <Link
-                href="/about-grandtex"
-                className="relative h-40 rounded-lg overflow-hidden transform transition-transform duration-300 hover:scale-[1.02] group"
-              >
-                <Image
-                  src="https://ext.same-assets.com/1118492138/1723594169.jpeg"
-                  alt="О GRANDTEX"
-                  fill
-                  style={{ objectFit: "cover" }}
-                  className="transition-transform duration-500 group-hover:scale-110"
-                />
-                <div className="absolute inset-0 bg-gradient-to-t from-black/80 to-transparent flex items-end p-6">
-                  <div>
-                    <span className="text-white font-medium text-xl mb-1 block">
-                      О GRANDTEX
-                    </span>
-                    <p className="text-gray-300 text-sm">
-                      Узнайте нашу историю, ценности и видение
-                    </p>
+              <AnimatedSection>
+                <Link
+                  href="/about-grandtex"
+                  className="relative h-40 rounded-lg overflow-hidden transform transition-transform duration-300 hover:scale-[1.02] group"
+                >
+                  <Image
+                    src="https://ext.same-assets.com/1118492138/1723594169.jpeg"
+                    alt="О GRANDTEX"
+                    fill
+                    style={{ objectFit: "cover" }}
+                    className="transition-transform duration-500 group-hover:scale-110"
+                  />
+                  <div className="absolute inset-0 bg-gradient-to-t from-black/80 to-transparent flex items-end p-6">
+                    <div>
+                      <span className="text-white font-medium text-xl mb-1 block">
+                        О GRANDTEX
+                      </span>
+                      <p className="text-gray-300 text-sm">
+                        Узнайте нашу историю, ценности и видение
+                      </p>
+                    </div>
                   </div>
-                </div>
-              </Link>
-              <Link
-                href="/tanneries"
-                className="relative h-40 rounded-lg overflow-hidden transform transition-transform duration-300 hover:scale-[1.02] group"
-              >
-                <Image
-                  src="https://ext.same-assets.com/1118492138/3036160331.jpeg"
-                  alt="Наши кожевенные заводы"
-                  fill
-                  style={{ objectFit: "cover" }}
-                  className="transition-transform duration-500 group-hover:scale-110"
-                />
-                <div className="absolute inset-0 bg-gradient-to-t from-black/80 to-transparent flex items-end p-6">
-                  <div>
-                    <span className="text-white font-medium text-xl mb-1 block">
-                      Наши кожевенные заводы
-                    </span>
-                    <p className="text-gray-300 text-sm">
-                      Ознакомьтесь с нашими передовыми производствами
-                    </p>
+                </Link>
+              </AnimatedSection>
+              <AnimatedSection delay={0.1}>
+                <Link
+                  href="/tanneries"
+                  className="relative h-40 rounded-lg overflow-hidden transform transition-transform duration-300 hover:scale-[1.02] group"
+                >
+                  <Image
+                    src="https://ext.same-assets.com/1118492138/3036160331.jpeg"
+                    alt="Наши кожевенные заводы"
+                    fill
+                    style={{ objectFit: "cover" }}
+                    className="transition-transform duration-500 group-hover:scale-110"
+                  />
+                  <div className="absolute inset-0 bg-gradient-to-t from-black/80 to-transparent flex items-end p-6">
+                    <div>
+                      <span className="text-white font-medium text-xl mb-1 block">
+                        Наши кожевенные заводы
+                      </span>
+                      <p className="text-gray-300 text-sm">
+                        Ознакомьтесь с нашими передовыми производствами
+                      </p>
+                    </div>
                   </div>
-                </div>
-              </Link>
+                </Link>
+              </AnimatedSection>
             </div>
             <div className="mt-8 flex justify-center md:justify-start">
               <Link
@@ -199,62 +204,59 @@ export default function Home() {
       </section>
 
       {/* Leathers Section */}
-      <section className="w-full py-24 px-8 bg-white opacity-0 animate-fade-in-scroll">
+      <section className="w-full py-24 px-8 bg-white">
         <div className="max-w-7xl mx-auto">
-          <div className="text-center mb-16 opacity-0 animate-fade-in-scroll">
+          <AnimatedSection className="text-center mb-16">
             <h2 className="text-4xl font-bold mb-4">Последняя коллекция</h2>
             <p className="text-xl text-gray-600 max-w-3xl mx-auto">
               Откройте нашу коллекцию Весна-Лето 27, включающую премиальные
               кожи, созданные для универсальности и высокой производительности.
             </p>
-          </div>
+          </AnimatedSection>
 
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8">
             {latestProducts.map((product, index) => (
-              <Link
-                key={product.id}
-                href={`/leathers/${product.id}`}
-                className="group bg-white border border-gray-200 rounded-lg overflow-hidden hover:shadow-lg transition-all duration-300 transform hover:-translate-y-1 opacity-0 animate-fade-in-scroll"
-                style={{ animationDelay: `${index * 150}ms` }}
-              >
-                <div className="relative aspect-square overflow-hidden">
-                  <Image
-                    src={product.image}
-                    alt={product.name}
-                    fill
-                    style={{ objectFit: "cover" }}
-                    className="transition-transform duration-500 group-hover:scale-110"
-                  />
-                </div>
-                <div className="p-6">
-                  <h3 className="text-xl font-bold group-hover:text-accent transition-colors">
-                    {product.name}
-                  </h3>
-                  <p className="text-sm text-gray-500 mt-1">
-                    {product.collection}
-                  </p>
-                  <div className="mt-4 space-y-1">
-                    <div className="flex justify-between">
-                      <span className="text-sm text-gray-500">Тип</span>
-                      <span className="text-sm">{product.type}</span>
-                    </div>
-                    <div className="flex justify-between">
-                      <span className="text-sm text-gray-500">Отделка</span>
-                      <span className="text-sm">{product.finish}</span>
-                    </div>
-                    <div className="flex justify-between">
-                      <span className="text-sm text-gray-500">Обработка</span>
-                      <span className="text-sm">{product.treatment}</span>
+              <AnimatedSection key={product.id} delay={index * 0.15}>
+                <Link
+                  href={`/leathers/${product.id}`}
+                  className="group block bg-white border border-gray-200 rounded-lg overflow-hidden hover:shadow-lg transition-all duration-300 transform hover:-translate-y-1"
+                >
+                  <div className="relative aspect-square overflow-hidden">
+                    <Image
+                      src={product.image}
+                      alt={product.name}
+                      fill
+                      style={{ objectFit: "cover" }}
+                      className="transition-transform duration-500 group-hover:scale-110"
+                    />
+                  </div>
+                  <div className="p-6">
+                    <h3 className="text-xl font-bold group-hover:text-accent transition-colors">
+                      {product.name}
+                    </h3>
+                    <p className="text-sm text-gray-500 mt-1">
+                      {product.collection}
+                    </p>
+                    <div className="mt-4 space-y-1">
+                      <div className="flex justify-between">
+                        <span className="text-sm text-gray-500">Тип</span>
+                        <span className="text-sm">{product.type}</span>
+                      </div>
+                      <div className="flex justify-between">
+                        <span className="text-sm text-gray-500">Отделка</span>
+                        <span className="text-sm">{product.finish}</span>
+                      </div>
+                      <div className="flex justify-between">
+                        <span className="text-sm text-gray-500">Обработка</span>
+                        <span className="text-sm">{product.treatment}</span>
+                      </div>
                     </div>
                   </div>
-                </div>
-              </Link>
+                </Link>
+              </AnimatedSection>
             ))}
           </div>
-          <div
-            className="mt-16 text-center opacity-0 animate-fade-in-scroll"
-            style={{ animationDelay: "600ms" }}
-          >
+          <AnimatedSection delay={0.6} className="mt-16 text-center">
             <p className="mb-8 text-gray-700 max-w-3xl mx-auto">
               От спортзала до офиса, коллекция SS27 отражает глубину и широту
               того, что GRANDTEX умеет лучше всего — создавать универсальные
@@ -269,7 +271,7 @@ export default function Home() {
             >
               Откройте коллекцию
             </Link>
-          </div>
+          </AnimatedSection>
         </div>
       </section>
 

--- a/src/components/AnimatedSection.tsx
+++ b/src/components/AnimatedSection.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import { motion, useInView, useScroll, useTransform } from "framer-motion";
+import { useRef } from "react";
+
+interface AnimatedSectionProps {
+  children: React.ReactNode;
+  /**
+   * Additional classes passed to the underlying motion.div
+   */
+  className?: string;
+  /**
+   * Controls parallax intensity. 0 disables the effect.
+   */
+  speed?: number;
+  /**
+   * Delay for the initial reveal animation in seconds.
+   */
+  delay?: number;
+}
+
+/**
+ * Utility wrapper that fades content in when it enters the viewport and
+ * optionally applies a parallax translation based on scroll position.
+ */
+export default function AnimatedSection({
+  children,
+  className = "",
+  speed = 0,
+  delay = 0,
+}: AnimatedSectionProps) {
+  const ref = useRef<HTMLDivElement>(null);
+  const inView = useInView(ref, { once: true, margin: "-100px" });
+
+  // Parallax effect – translate on the Y axis as the page scrolls
+  const { scrollYProgress } = useScroll({
+    target: ref,
+    offset: ["start end", "end start"],
+  });
+  const y = useTransform(scrollYProgress, [0, 1], [speed * 50, speed * -50]);
+
+  return (
+    <motion.div
+      ref={ref}
+      className={className}
+      style={speed ? { y } : undefined}
+      initial={{ opacity: 0, y: 40 }}
+      animate={inView ? { opacity: 1, y: 0 } : undefined}
+      transition={{ duration: 0.6, delay }}
+    >
+      {children}
+    </motion.div>
+  );
+}

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import Image from "next/image";
 import { Sheet, SheetContent, SheetTrigger } from "@/components/ui/sheet";
 import { usePathname } from "next/navigation";
+import AnimatedSection from "@/components/AnimatedSection";
 
 export default function Header({ transparent = false }) {
   const [isScrolled, setIsScrolled] = useState(false);
@@ -126,7 +127,7 @@ export default function Header({ transparent = false }) {
             side="right"
             className="w-full sm:max-w-md md:max-w-lg lg:max-w-xl p-0 overflow-y-auto"
           >
-            <div className="h-full flex flex-col">
+            <AnimatedSection className="h-full flex flex-col">
               <div className="flex justify-between items-center px-8 py-6 border-b">
                 <Link href="/" className="text-3xl font-bold">
                   grandtex
@@ -143,7 +144,11 @@ export default function Header({ transparent = false }) {
                 <nav className="space-y-12">
                   <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
                     {navLinks.slice(0, 4).map((link, index) => (
-                      <div key={link.title} className="space-y-4">
+                      <AnimatedSection
+                        key={link.title}
+                        delay={index * 0.1}
+                        className="space-y-4"
+                      >
                         <Link
                           href={link.href}
                           className="flex items-center space-x-2 text-lg font-medium hover:text-accent transition-colors"
@@ -186,11 +191,11 @@ export default function Header({ transparent = false }) {
                             </div>
                           </div>
                         )}
-                      </div>
+                      </AnimatedSection>
                     ))}
                   </div>
 
-                  <div className="space-y-4">
+                  <AnimatedSection delay={0.4} className="space-y-4">
                     <h2 className="text-lg font-medium">
                       Дополнительная информация
                     </h2>
@@ -210,7 +215,7 @@ export default function Header({ transparent = false }) {
                         </li>
                       ))}
                     </ul>
-                  </div>
+                  </AnimatedSection>
                 </nav>
               </div>
 
@@ -242,7 +247,7 @@ export default function Header({ transparent = false }) {
                   </Link>
                 </div>
               </div>
-            </div>
+            </AnimatedSection>
           </SheetContent>
         </Sheet>
       </div>


### PR DESCRIPTION
## Summary
- add gsap dependency and reusable `AnimatedSection` component for scroll reveal and parallax
- animate hero, product cards, and navigation drawer with framer-motion

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run format`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b04527674883258c0168aa0f511140