### PR TITLE
Respect reduced motion preference for animations

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -64,3 +64,23 @@
     text-wrap: balance;
   }
 }
+
+@layer utilities {
+  @media (prefers-reduced-motion: reduce) {
+    .animate-fade-in-scroll {
+      opacity: 1 !important;
+      transform: none !important;
+      transition: none !important;
+    }
+
+    [data-parallax] {
+      transform: none !important;
+    }
+
+    [data-product-card],
+    [data-product-card] [data-product-image] {
+      transform: none !important;
+      transition: none !important;
+    }
+  }
+}

--- a/src/lib/animate.ts
+++ b/src/lib/animate.ts
@@ -1,68 +1,97 @@
-'use client';
+"use client";
 
 export const initScrollAnimations = () => {
-  if (typeof window === 'undefined') return;
+  if (typeof window === "undefined") return;
 
-  const fadeElements = document.querySelectorAll('.animate-fade-in-scroll');
+  const fadeElements = document.querySelectorAll(".animate-fade-in-scroll");
 
-  const observer = new IntersectionObserver((entries) => {
-    entries.forEach(entry => {
-      if (entry.isIntersecting) {
-        entry.target.classList.add('animate-fade-in-up');
-        observer.unobserve(entry.target);
-      }
+  if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) {
+    fadeElements.forEach((element) => {
+      const el = element as HTMLElement;
+      el.style.opacity = "1";
+      el.style.transform = "none";
     });
-  }, { threshold: 0.1 });
+    return;
+  }
 
-  fadeElements.forEach(element => {
+  const observer = new IntersectionObserver(
+    (entries) => {
+      entries.forEach((entry) => {
+        if (entry.isIntersecting) {
+          entry.target.classList.add("animate-fade-in-up");
+          observer.unobserve(entry.target);
+        }
+      });
+    },
+    { threshold: 0.1 },
+  );
+
+  fadeElements.forEach((element) => {
     observer.observe(element);
   });
 };
 
 export const initParallaxEffect = () => {
-  if (typeof window === 'undefined') return;
+  if (typeof window === "undefined") return;
 
-  const parallaxElements = document.querySelectorAll('[data-parallax]');
+  const parallaxElements = document.querySelectorAll("[data-parallax]");
+
+  if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) {
+    parallaxElements.forEach((element) => {
+      (element as HTMLElement).style.transform = "none";
+    });
+    return;
+  }
 
   const handleScroll = () => {
     const scrollTop = window.scrollY;
 
     parallaxElements.forEach((element) => {
-      const speed = Number(element.getAttribute('data-parallax-speed')) || 0.2;
+      const speed = Number(element.getAttribute("data-parallax-speed")) || 0.2;
       const offset = scrollTop * speed;
       (element as HTMLElement).style.transform = `translateY(${offset}px)`;
     });
   };
 
-  window.addEventListener('scroll', handleScroll);
+  window.addEventListener("scroll", handleScroll);
 
   // Cleanup function
   return () => {
-    window.removeEventListener('scroll', handleScroll);
+    window.removeEventListener("scroll", handleScroll);
   };
 };
 
 export const initProductHoverEffects = () => {
-  if (typeof window === 'undefined') return;
+  if (typeof window === "undefined") return;
 
-  const productCards = document.querySelectorAll('[data-product-card]');
+  const productCards = document.querySelectorAll("[data-product-card]");
 
-  productCards.forEach(card => {
-    card.addEventListener('mouseenter', () => {
-      card.classList.add('scale-[1.02]');
-
-      const image = card.querySelector('[data-product-image]');
+  if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) {
+    productCards.forEach((card) => {
+      const image = card.querySelector("[data-product-image]");
       if (image) {
-        image.classList.add('scale-110');
+        (image as HTMLElement).style.transform = "none";
+      }
+    });
+    return;
+  }
+
+  productCards.forEach((card) => {
+    card.addEventListener("mouseenter", () => {
+      card.classList.add("scale-[1.02]");
+
+      const image = card.querySelector("[data-product-image]");
+      if (image) {
+        image.classList.add("scale-110");
       }
     });
 
-    card.addEventListener('mouseleave', () => {
-      card.classList.remove('scale-[1.02]');
+    card.addEventListener("mouseleave", () => {
+      card.classList.remove("scale-[1.02]");
 
-      const image = card.querySelector('[data-product-image]');
+      const image = card.querySelector("[data-product-image]");
       if (image) {
-        image.classList.remove('scale-110');
+        image.classList.remove("scale-110");
       }
     });
   });


### PR DESCRIPTION
## Summary
- Skip scroll, parallax, and product hover animations when user prefers reduced motion
- Add reduced-motion CSS fallbacks for animated elements

## Testing
- `bun run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b045bd14b88325b3fab8145c0d918f