### PR TITLE
feat: add theme toggle and provider

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,6 +4,7 @@ import "./globals.css";
 import ClientBody from "./ClientBody";
 import Script from "next/script";
 import Animations from "./animations";
+import { ThemeProvider } from "@/components/ThemeProvider";
 
 const inter = Inter({
   variable: "--font-inter",
@@ -93,10 +94,12 @@ export default function RootLayout({
         />
       </head>
       <body suppressHydrationWarning className="antialiased">
-        <ClientBody>
-          <Animations />
-          {children}
-        </ClientBody>
+        <ThemeProvider>
+          <ClientBody>
+            <Animations />
+            {children}
+          </ClientBody>
+        </ThemeProvider>
       </body>
     </html>
   );

--- a/src/components/ThemeProvider.tsx
+++ b/src/components/ThemeProvider.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import { createContext, useContext, useEffect, useState } from "react";
+
+interface ThemeContextValue {
+  theme: "light" | "dark";
+  toggle: () => void;
+}
+
+const ThemeContext = createContext<ThemeContextValue>({
+  theme: "light",
+  toggle: () => {},
+});
+
+export function ThemeProvider({ children }: { children: React.ReactNode }) {
+  const [theme, setTheme] = useState<"light" | "dark">("light");
+
+  // Initialize theme from localStorage or system preference
+  useEffect(() => {
+    const stored = window.localStorage.getItem("theme") as
+      | "light"
+      | "dark"
+      | null;
+    if (stored) {
+      setTheme(stored);
+    } else if (window.matchMedia("(prefers-color-scheme: dark)").matches) {
+      setTheme("dark");
+    }
+  }, []);
+
+  // Apply theme class to <html> element and persist
+  useEffect(() => {
+    const root = window.document.documentElement;
+    if (theme === "dark") {
+      root.classList.add("dark");
+    } else {
+      root.classList.remove("dark");
+    }
+    window.localStorage.setItem("theme", theme);
+  }, [theme]);
+
+  const toggle = () => setTheme(theme === "light" ? "dark" : "light");
+
+  return (
+    <ThemeContext.Provider value={{ theme, toggle }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+}
+
+export function useTheme() {
+  return useContext(ThemeContext);
+}
+

--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import { Sun, Moon } from "lucide-react";
+import { useTheme } from "./ThemeProvider";
+import { cn } from "@/lib/utils";
+
+interface ThemeToggleProps {
+  className?: string;
+}
+
+export default function ThemeToggle({ className }: ThemeToggleProps) {
+  const { theme, toggle } = useTheme();
+
+  return (
+    <button
+      type="button"
+      onClick={toggle}
+      aria-label="Переключить тему"
+      className={cn(
+        "p-2 rounded-md transition-colors hover:bg-gray-200 dark:hover:bg-gray-700",
+        className
+      )}
+    >
+      {theme === "light" ? (
+        <Moon className="h-5 w-5" />
+      ) : (
+        <Sun className="h-5 w-5" />
+      )}
+    </button>
+  );
+}
+

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -6,6 +6,7 @@ import Image from "next/image";
 import { Sheet, SheetContent, SheetTrigger } from "@/components/ui/sheet";
 import { usePathname } from "next/navigation";
 import AnimatedSection from "@/components/AnimatedSection";
+import ThemeToggle from "@/components/ThemeToggle";
 
 export default function Header({ transparent = false }) {
   const [isScrolled, setIsScrolled] = useState(false);
@@ -114,19 +115,21 @@ export default function Header({ transparent = false }) {
           GRANDTEX
         </Link>
 
-        <Sheet>
-          <SheetTrigger asChild>
-            <button
-              className={`flex items-center space-x-2 transition-colors duration-300 ${textClasses} hover:opacity-75`}
-              onClick={() => setIsMenuOpen(true)}
+        <div className="flex items-center space-x-4">
+          <ThemeToggle className={textClasses} />
+          <Sheet>
+            <SheetTrigger asChild>
+              <button
+                className={`flex items-center space-x-2 transition-colors duration-300 ${textClasses} hover:opacity-75`}
+                onClick={() => setIsMenuOpen(true)}
+              >
+                <span>Меню</span>
+              </button>
+            </SheetTrigger>
+            <SheetContent
+              side="right"
+              className="w-full sm:max-w-md md:max-w-lg lg:max-w-xl p-0 overflow-y-auto"
             >
-              <span>Меню</span>
-            </button>
-          </SheetTrigger>
-          <SheetContent
-            side="right"
-            className="w-full sm:max-w-md md:max-w-lg lg:max-w-xl p-0 overflow-y-auto"
-          >
             <AnimatedSection className="h-full flex flex-col">
               <div className="flex justify-between items-center px-8 py-6 border-b">
                 <Link href="/" className="text-3xl font-bold">
@@ -249,7 +252,8 @@ export default function Header({ transparent = false }) {
               </div>
             </AnimatedSection>
           </SheetContent>
-        </Sheet>
+          </Sheet>
+        </div>
       </div>
     </header>
   );


### PR DESCRIPTION
## Summary
- add ThemeProvider for storing light/dark selection
- include ThemeToggle button in header to switch themes

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b055319cf88325bdd530edf39d0c74