### PR TITLE
refactor: apply brand color palette

### DIFF
--- a/src/app/about-grandtex/page.tsx
+++ b/src/app/about-grandtex/page.tsx
@@ -6,7 +6,7 @@ export default function AboutPage() {
   return (
     <MainLayout>
       {/* Hero Section */}
-      <section className="relative w-full h-[60vh] bg-black text-white mt-20">
+      <section className="relative w-full h-[60vh] bg-primary text-primary-foreground mt-20">
         <div className="absolute inset-0 z-0">
           <Image
             src="https://ext.same-assets.com/1118492138/1723594169.jpeg"
@@ -78,18 +78,18 @@ export default function AboutPage() {
           </div>
 
           <div className="my-16 grid grid-cols-1 md:grid-cols-2 gap-8">
-            <div className="bg-gray-100 p-8 rounded-lg">
+            <div className="bg-muted p-8 rounded-lg">
               <h3 className="text-2xl font-bold mb-4">Наша миссия</h3>
-              <p className="text-gray-700">
+              <p className="text-muted-foreground">
                 Создавать превосходные кожаные изделия с использованием
                 инновационных и устойчивых практик, выступая надёжным партнёром
                 для брендов по всему миру.
               </p>
             </div>
 
-            <div className="bg-gray-100 p-8 rounded-lg">
+            <div className="bg-muted p-8 rounded-lg">
               <h3 className="text-2xl font-bold mb-4">Наше видение</h3>
-              <p className="text-gray-700">
+              <p className="text-muted-foreground">
                 Лидировать в кожевенной отрасли по показателям устойчивости,
                 инноваций и качества, устанавливая новые стандарты
                 ответственного производства.
@@ -103,9 +103,9 @@ export default function AboutPage() {
             <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
               {[1, 2, 3].map((i) => (
                 <div key={i} className="text-center">
-                  <div className="aspect-square bg-gray-200 rounded-full w-48 h-48 mx-auto mb-4"></div>
+                  <div className="aspect-square bg-muted rounded-full w-48 h-48 mx-auto mb-4"></div>
                   <h3 className="text-xl font-bold">Имя руководителя</h3>
-                  <p className="text-gray-500">Должность</p>
+                  <p className="text-muted-foreground">Должность</p>
                 </div>
               ))}
             </div>
@@ -114,7 +114,7 @@ export default function AboutPage() {
       </section>
 
       {/* CTA Section */}
-      <section className="py-16 px-8 bg-gray-100">
+      <section className="py-16 px-8 bg-muted">
         <div className="max-w-4xl mx-auto text-center">
           <h2 className="text-3xl font-bold mb-4">
             Присоединяйтесь к нашему пути
@@ -125,7 +125,7 @@ export default function AboutPage() {
           </p>
           <Link
             href="/contact"
-            className="px-8 py-3 bg-black text-white rounded-full text-lg inline-block"
+            className="px-8 py-3 bg-primary text-primary-foreground rounded-full text-lg inline-block"
           >
             Свяжитесь с нами
           </Link>

--- a/src/app/collections/[id]/page.tsx
+++ b/src/app/collections/[id]/page.tsx
@@ -137,7 +137,7 @@ export default async function CollectionDetailPage({
           </p>
           <Link
             href="/collections"
-            className="px-6 py-2 bg-black text-white rounded-full"
+            className="px-6 py-2 bg-primary text-primary-foreground rounded-full"
           >
             Вернуться к коллекциям
           </Link>
@@ -150,7 +150,7 @@ export default async function CollectionDetailPage({
     <MainLayout>
       <div className="mt-20">
         {/* Hero Section */}
-        <section className="relative w-full h-[60vh] bg-black text-white">
+        <section className="relative w-full h-[60vh] bg-primary text-primary-foreground">
           <div className="absolute inset-0 z-0">
             <Image
               src={collection.mainImage}
@@ -188,11 +188,11 @@ export default async function CollectionDetailPage({
                   <h3 className="text-xl font-bold mb-4">Темы коллекции</h3>
                   <div className="space-y-4">
                     {collection.themes.map((theme, index) => (
-                      <div key={index} className="bg-gray-50 p-5 rounded-md">
+                      <div key={index} className="bg-secondary p-5 rounded-md">
                         <h4 className="text-lg font-bold mb-2">
                           {theme.title}
                         </h4>
-                        <p className="text-gray-700">{theme.description}</p>
+                        <p className="text-muted-foreground">{theme.description}</p>
                       </div>
                     ))}
                   </div>
@@ -201,7 +201,7 @@ export default async function CollectionDetailPage({
                 <div className="mt-8">
                   <Link
                     href="#"
-                    className="px-6 py-3 bg-black text-white rounded-full inline-block"
+                    className="px-6 py-3 bg-primary text-primary-foreground rounded-full inline-block"
                   >
                     Скачать лукбук
                   </Link>
@@ -230,7 +230,7 @@ export default async function CollectionDetailPage({
         </section>
 
         {/* Collection Products */}
-        <section className="py-16 px-8 bg-gray-50">
+        <section className="py-16 px-8 bg-secondary">
           <div className="container mx-auto">
             <h2 className="text-3xl font-bold mb-12">Избранные кожи</h2>
 
@@ -239,7 +239,7 @@ export default async function CollectionDetailPage({
                 <Link
                   key={product.id}
                   href={`/leathers/${product.id}`}
-                  className="group bg-white border border-gray-200 rounded-md overflow-hidden hover:shadow-md transition-shadow"
+                  className="group bg-background border border-border rounded-md overflow-hidden hover:shadow-md transition-shadow"
                 >
                   <div className="relative aspect-square">
                     <Image
@@ -253,7 +253,7 @@ export default async function CollectionDetailPage({
                     <h3 className="text-xl font-bold mb-1 group-hover:text-accent transition-colors">
                       {product.name}
                     </h3>
-                    <p className="text-sm text-gray-500">{product.type}</p>
+                    <p className="text-sm text-muted-foreground">{product.type}</p>
                   </div>
                 </Link>
               ))}
@@ -262,7 +262,7 @@ export default async function CollectionDetailPage({
             <div className="mt-12 text-center">
               <Link
                 href="/leathers"
-                className="px-6 py-3 border border-black rounded-full inline-block"
+                className="px-6 py-3 border border-primary rounded-full inline-block"
               >
                 Смотреть все кожи
               </Link>
@@ -274,7 +274,7 @@ export default async function CollectionDetailPage({
         <section className="py-16 px-8">
           <div className="container mx-auto">
             <h2 className="text-3xl font-bold mb-6">Применение</h2>
-            <p className="text-lg text-gray-700 mb-12 max-w-3xl">
+            <p className="text-lg text-muted-foreground mb-12 max-w-3xl">
               Коллекция {collection.title} разработана для универсальности в
               различных категориях продукции. Вот некоторые ключевые области
               применения кож этого сезона.
@@ -284,9 +284,9 @@ export default async function CollectionDetailPage({
               {["Обувь", "Аксессуары", "Одежда", "Товары для дома"].map(
                 (application, index) => (
                   <div key={index} className="text-center">
-                    <div className="w-20 h-20 bg-gray-200 rounded-full mx-auto mb-4"></div>
+                    <div className="w-20 h-20 bg-muted rounded-full mx-auto mb-4"></div>
                     <h3 className="text-xl font-bold mb-2">{application}</h3>
-                    <p className="text-gray-700">
+                    <p className="text-muted-foreground">
                       Кожи, специально разработанные для превосходства в
                       применении в области {application.toLowerCase()}.
                     </p>
@@ -298,7 +298,7 @@ export default async function CollectionDetailPage({
         </section>
 
         {/* Contact Section */}
-        <section className="py-16 px-8 bg-gray-900 text-white">
+        <section className="py-16 px-8 bg-primary text-primary-foreground">
           <div className="container mx-auto text-center">
             <h2 className="text-3xl font-bold mb-4">
               Заинтересованы в этой коллекции?
@@ -310,13 +310,13 @@ export default async function CollectionDetailPage({
             <div className="flex flex-wrap justify-center gap-4">
               <Link
                 href="/contact"
-                className="px-6 py-3 bg-white text-gray-900 rounded-full"
+                className="px-6 py-3 bg-background text-foreground rounded-full"
               >
                 Запросить образцы
               </Link>
               <Link
                 href="/contact"
-                className="px-6 py-3 border border-white text-white rounded-full"
+                className="px-6 py-3 border border-background text-primary-foreground rounded-full"
               >
                 Связаться с отделом продаж
               </Link>

--- a/src/app/collections/page.tsx
+++ b/src/app/collections/page.tsx
@@ -49,7 +49,7 @@ export default function CollectionsPage() {
   return (
     <MainLayout>
       {/* Hero Section */}
-      <section className="relative w-full h-[40vh] bg-black text-white mt-20">
+      <section className="relative w-full h-[40vh] bg-primary text-primary-foreground mt-20">
         <div className="absolute inset-0 z-0">
           <Image
             src="https://ext.same-assets.com/1118492138/1829320189.jpeg"
@@ -87,13 +87,13 @@ export default function CollectionsPage() {
             </div>
 
             <div className="lg:w-1/2 flex flex-col justify-center">
-              <div className="inline-block px-4 py-1 bg-accent text-white rounded-full text-sm font-medium mb-4">
+              <div className="inline-block px-4 py-1 bg-accent text-primary-foreground rounded-full text-sm font-medium mb-4">
                 Последняя коллекция
               </div>
               <h2 className="text-4xl font-bold mb-4">
                 {collections[0].title}
               </h2>
-              <p className="text-lg text-gray-700 mb-8">
+              <p className="text-lg text-muted-foreground mb-8">
                 {collections[0].description}
               </p>
               <p className="mb-8">
@@ -105,7 +105,7 @@ export default function CollectionsPage() {
               </p>
               <Link
                 href={`/collections/${collections[0].id}`}
-                className="px-6 py-3 bg-black text-white rounded-full inline-block self-start"
+                className="px-6 py-3 bg-primary text-primary-foreground rounded-full inline-block self-start"
               >
                 Посмотреть коллекцию
               </Link>
@@ -115,7 +115,7 @@ export default function CollectionsPage() {
       </section>
 
       {/* Past Collections */}
-      <section className="py-16 px-8 bg-gray-50">
+      <section className="py-16 px-8 bg-secondary">
         <div className="container mx-auto">
           <h2 className="text-3xl font-bold mb-12">Прошлые коллекции</h2>
 
@@ -124,7 +124,7 @@ export default function CollectionsPage() {
               <Link
                 key={collection.id}
                 href={`/collections/${collection.id}`}
-                className="group bg-white border border-gray-200 rounded-lg overflow-hidden hover:shadow-md transition-shadow"
+                className="group bg-background border border-border rounded-lg overflow-hidden hover:shadow-md transition-shadow"
               >
                 <div className="relative aspect-video">
                   <Image
@@ -138,9 +138,9 @@ export default function CollectionsPage() {
                   <h3 className="text-xl font-bold mb-2 group-hover:text-accent transition-colors">
                     {collection.title}
                   </h3>
-                  <p className="text-gray-700 mb-4">{collection.description}</p>
+                  <p className="text-muted-foreground mb-4">{collection.description}</p>
                   <div className="flex justify-between items-center">
-                    <span className="text-sm text-gray-500">
+                    <span className="text-sm text-muted-foreground">
                       {collection.season}, {collection.year}
                     </span>
                     <span className="text-accent font-medium group-hover:underline">
@@ -158,17 +158,17 @@ export default function CollectionsPage() {
       <section className="py-16 px-8">
         <div className="container mx-auto text-center">
           <h2 className="text-3xl font-bold mb-4">Лукбуки коллекций</h2>
-          <p className="text-lg text-gray-700 mb-12 max-w-3xl mx-auto">
+          <p className="text-lg text-muted-foreground mb-12 max-w-3xl mx-auto">
             Скачайте наши лукбуки, чтобы получить подробную информацию о
             характеристиках кожи, цветах и применении.
           </p>
 
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
             {collections.map((collection) => (
-              <div key={collection.id} className="bg-gray-50 p-6 rounded-lg">
+              <div key={collection.id} className="bg-secondary p-6 rounded-lg">
                 <h3 className="text-xl font-bold mb-2">{collection.title}</h3>
-                <p className="text-gray-600 mb-4">Лукбук</p>
-                <button className="px-4 py-2 bg-black text-white rounded-md text-sm w-full">
+                <p className="text-muted-foreground mb-4">Лукбук</p>
+                <button className="px-4 py-2 bg-primary text-primary-foreground rounded-md text-sm w-full">
                   Скачать PDF
                 </button>
               </div>
@@ -178,7 +178,7 @@ export default function CollectionsPage() {
       </section>
 
       {/* Contact CTA */}
-      <section className="py-16 px-8 bg-gray-900 text-white">
+      <section className="py-16 px-8 bg-primary text-primary-foreground">
         <div className="container mx-auto text-center">
           <h2 className="text-3xl font-bold mb-4">
             Нужны индивидуальные решения?
@@ -189,7 +189,7 @@ export default function CollectionsPage() {
           </p>
           <Link
             href="/contact"
-            className="px-8 py-3 bg-white text-gray-900 rounded-full text-lg inline-block"
+            className="px-8 py-3 bg-background text-foreground rounded-full text-lg inline-block"
           >
             Свяжитесь с нашей командой
           </Link>

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -6,7 +6,7 @@ export default function ContactPage() {
   return (
     <MainLayout>
       {/* Hero Section */}
-      <section className="relative w-full h-[40vh] bg-black text-white mt-20">
+      <section className="relative w-full h-[40vh] bg-primary text-primary-foreground mt-20">
         <div className="absolute inset-0 z-0">
           <Image
             src="https://ext.same-assets.com/1118492138/271436679.jpeg"
@@ -39,14 +39,14 @@ export default function ContactPage() {
                 <div>
                   <label
                     htmlFor="firstName"
-                    className="block text-sm font-medium text-gray-700 mb-1"
+                    className="block text-sm font-medium text-muted-foreground mb-1"
                   >
                     Имя*
                   </label>
                   <input
                     type="text"
                     id="firstName"
-                    className="w-full px-4 py-2 border border-gray-300 rounded-md"
+                    className="w-full px-4 py-2 border border-border rounded-md"
                     required
                   />
                 </div>
@@ -54,14 +54,14 @@ export default function ContactPage() {
                 <div>
                   <label
                     htmlFor="lastName"
-                    className="block text-sm font-medium text-gray-700 mb-1"
+                    className="block text-sm font-medium text-muted-foreground mb-1"
                   >
                     Фамилия*
                   </label>
                   <input
                     type="text"
                     id="lastName"
-                    className="w-full px-4 py-2 border border-gray-300 rounded-md"
+                    className="w-full px-4 py-2 border border-border rounded-md"
                     required
                   />
                 </div>
@@ -70,14 +70,14 @@ export default function ContactPage() {
               <div>
                 <label
                   htmlFor="email"
-                  className="block text-sm font-medium text-gray-700 mb-1"
+                  className="block text-sm font-medium text-muted-foreground mb-1"
                 >
                   Электронная почта*
                 </label>
                 <input
                   type="email"
                   id="email"
-                  className="w-full px-4 py-2 border border-gray-300 rounded-md"
+                  className="w-full px-4 py-2 border border-border rounded-md"
                   required
                 />
               </div>
@@ -85,28 +85,28 @@ export default function ContactPage() {
               <div>
                 <label
                   htmlFor="company"
-                  className="block text-sm font-medium text-gray-700 mb-1"
+                  className="block text-sm font-medium text-muted-foreground mb-1"
                 >
                   Компания
                 </label>
                 <input
                   type="text"
                   id="company"
-                  className="w-full px-4 py-2 border border-gray-300 rounded-md"
+                  className="w-full px-4 py-2 border border-border rounded-md"
                 />
               </div>
 
               <div>
                 <label
                   htmlFor="subject"
-                  className="block text-sm font-medium text-gray-700 mb-1"
+                  className="block text-sm font-medium text-muted-foreground mb-1"
                 >
                   Тема*
                 </label>
                 <input
                   type="text"
                   id="subject"
-                  className="w-full px-4 py-2 border border-gray-300 rounded-md"
+                  className="w-full px-4 py-2 border border-border rounded-md"
                   required
                 />
               </div>
@@ -114,14 +114,14 @@ export default function ContactPage() {
               <div>
                 <label
                   htmlFor="message"
-                  className="block text-sm font-medium text-gray-700 mb-1"
+                  className="block text-sm font-medium text-muted-foreground mb-1"
                 >
                   Сообщение*
                 </label>
                 <textarea
                   id="message"
                   rows={6}
-                  className="w-full px-4 py-2 border border-gray-300 rounded-md"
+                  className="w-full px-4 py-2 border border-border rounded-md"
                   required
                 ></textarea>
               </div>
@@ -129,7 +129,7 @@ export default function ContactPage() {
               <div>
                 <button
                   type="submit"
-                  className="px-6 py-3 bg-black text-white rounded-md"
+                  className="px-6 py-3 bg-primary text-primary-foreground rounded-md"
                 >
                   Отправить
                 </button>
@@ -143,7 +143,7 @@ export default function ContactPage() {
             <div className="space-y-10">
               <div>
                 <h3 className="text-xl font-bold mb-2">Китай</h3>
-                <p className="text-gray-600 mb-4">
+                <p className="text-muted-foreground mb-4">
                   GRANDTEX Leather Co., Ltd.
                   <br />
                   123 Industrial Avenue
@@ -154,12 +154,12 @@ export default function ContactPage() {
                   <br />
                   Email: info.china@grandtex.com
                 </p>
-                <div className="bg-gray-200 h-48 rounded-md"></div>
+                <div className="bg-muted h-48 rounded-md"></div>
               </div>
 
               <div>
                 <h3 className="text-xl font-bold mb-2">Вьетнам</h3>
-                <p className="text-gray-600 mb-4">
+                <p className="text-muted-foreground mb-4">
                   GRANDTEX Vietnam Co., Ltd.
                   <br />
                   456 Manufacturing Boulevard
@@ -170,12 +170,12 @@ export default function ContactPage() {
                   <br />
                   Email: info.vietnam@grandtex.com
                 </p>
-                <div className="bg-gray-200 h-48 rounded-md"></div>
+                <div className="bg-muted h-48 rounded-md"></div>
               </div>
 
               <div>
                 <h3 className="text-xl font-bold mb-2">США</h3>
-                <p className="text-gray-600 mb-4">
+                <p className="text-muted-foreground mb-4">
                   GRANDTEX America Inc.
                   <br />
                   789 Corporate Plaza
@@ -186,7 +186,7 @@ export default function ContactPage() {
                   <br />
                   Email: info.usa@grandtex.com
                 </p>
-                <div className="bg-gray-200 h-48 rounded-md"></div>
+                <div className="bg-muted h-48 rounded-md"></div>
               </div>
             </div>
           </div>
@@ -194,50 +194,50 @@ export default function ContactPage() {
       </section>
 
       {/* Inquiry Types */}
-      <section className="py-16 px-8 bg-gray-50">
+      <section className="py-16 px-8 bg-secondary">
         <div className="max-w-6xl mx-auto">
           <h2 className="text-3xl font-bold mb-8 text-center">
             Как мы можем помочь?
           </h2>
 
           <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
-            <div className="bg-white p-8 rounded-lg shadow-sm">
+            <div className="bg-background p-8 rounded-lg shadow-sm">
               <h3 className="text-xl font-bold mb-4">Вопросы по продажам</h3>
-              <p className="text-gray-600 mb-4">
+              <p className="text-muted-foreground mb-4">
                 Интересует наша продукция? Наша команда по продажам готова
                 предоставить информацию о товарах, образцах и ценах.
               </p>
               <Link
                 href="mailto:sales@grandtex.com"
-                className="text-black font-medium hover:underline"
+                className="text-foreground font-medium hover:underline"
               >
                 sales@grandtex.com
               </Link>
             </div>
 
-            <div className="bg-white p-8 rounded-lg shadow-sm">
+            <div className="bg-background p-8 rounded-lg shadow-sm">
               <h3 className="text-xl font-bold mb-4">Техническая поддержка</h3>
-              <p className="text-gray-600 mb-4">
+              <p className="text-muted-foreground mb-4">
                 Нужна техническая помощь по нашей продукции? Наши специалисты
                 готовы ответить на ваши вопросы и дать рекомендации.
               </p>
               <Link
                 href="mailto:support@grandtex.com"
-                className="text-black font-medium hover:underline"
+                className="text-foreground font-medium hover:underline"
               >
                 support@grandtex.com
               </Link>
             </div>
 
-            <div className="bg-white p-8 rounded-lg shadow-sm">
+            <div className="bg-background p-8 rounded-lg shadow-sm">
               <h3 className="text-xl font-bold mb-4">Устойчивость</h3>
-              <p className="text-gray-600 mb-4">
+              <p className="text-muted-foreground mb-4">
                 Хотите узнать больше о наших инициативах в области устойчивости?
                 Свяжитесь с нашей командой по устойчивому развитию.
               </p>
               <Link
                 href="mailto:sustainability@grandtex.com"
-                className="text-black font-medium hover:underline"
+                className="text-foreground font-medium hover:underline"
               >
                 sustainability@grandtex.com
               </Link>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -4,48 +4,48 @@
 
 @layer base {
   :root {
-    --background: 20 33% 92%;
-    --foreground: 0 0% 3%;
-    --card: 0 0% 100%;
-    --card-foreground: 0 0% 3%;
-    --popover: 0 0% 100%;
-    --popover-foreground: 0 0% 3%;
-    --primary: 20 10% 12%;
+    --background: 30 20% 95%;
+    --foreground: 25 15% 15%;
+    --card: 30 20% 98%;
+    --card-foreground: 25 15% 15%;
+    --popover: 30 20% 98%;
+    --popover-foreground: 25 15% 15%;
+    --primary: 25 76% 42%;
     --primary-foreground: 0 0% 98%;
-    --secondary: 20 5% 95%;
-    --secondary-foreground: 20 10% 12%;
-    --muted: 20 5% 95%;
-    --muted-foreground: 20 5% 40%;
-    --accent: 35 80% 60%;
+    --secondary: 30 30% 85%;
+    --secondary-foreground: 25 15% 15%;
+    --muted: 30 20% 90%;
+    --muted-foreground: 25 10% 40%;
+    --accent: 15 75% 45%;
     --accent-foreground: 0 0% 98%;
-    --destructive: 0 84.2% 60.2%;
+    --destructive: 0 72% 45%;
     --destructive-foreground: 0 0% 98%;
-    --border: 20 5% 90%;
-    --input: 20 5% 90%;
-    --ring: 20 10% 12%;
+    --border: 30 20% 80%;
+    --input: 30 20% 80%;
+    --ring: 25 76% 42%;
     --radius: 0rem;
   }
 
   .dark {
-    --background: 0 0% 3%;
-    --foreground: 0 0% 98%;
-    --card: 0 0% 3%;
-    --card-foreground: 0 0% 98%;
-    --popover: 0 0% 3%;
-    --popover-foreground: 0 0% 98%;
-    --primary: 0 0% 98%;
-    --primary-foreground: 0 0% 3%;
-    --secondary: 0 0% 15%;
-    --secondary-foreground: 0 0% 98%;
-    --muted: 0 0% 15%;
-    --muted-foreground: 0 0% 65%;
-    --accent: 35 80% 60%;
-    --accent-foreground: 0 0% 3%;
-    --destructive: 0 62.8% 30.6%;
+    --background: 25 15% 10%;
+    --foreground: 30 20% 95%;
+    --card: 25 15% 13%;
+    --card-foreground: 30 20% 95%;
+    --popover: 25 15% 13%;
+    --popover-foreground: 30 20% 95%;
+    --primary: 25 76% 42%;
+    --primary-foreground: 0 0% 98%;
+    --secondary: 25 15% 20%;
+    --secondary-foreground: 30 20% 95%;
+    --muted: 25 15% 20%;
+    --muted-foreground: 30 15% 70%;
+    --accent: 15 75% 45%;
+    --accent-foreground: 25 15% 10%;
+    --destructive: 0 62% 30%;
     --destructive-foreground: 0 0% 98%;
-    --border: 0 0% 15%;
-    --input: 0 0% 15%;
-    --ring: 0 0% 83.9%;
+    --border: 25 15% 20%;
+    --input: 25 15% 20%;
+    --ring: 25 76% 42%;
   }
 }
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -72,8 +72,8 @@ export const metadata: Metadata = {
 
 export const viewport: Viewport = {
   themeColor: [
-    { media: "(prefers-color-scheme: light)", color: "#ffffff" },
-    { media: "(prefers-color-scheme: dark)", color: "#000000" },
+    { media: "(prefers-color-scheme: light)", color: "#f5f2f0" },
+    { media: "(prefers-color-scheme: dark)", color: "#1d1916" },
   ],
   width: "device-width",
   initialScale: 1,

--- a/src/app/leathers/[id]/page.tsx
+++ b/src/app/leathers/[id]/page.tsx
@@ -124,7 +124,7 @@ export default async function LeatherDetailPage({
           </p>
           <Link
             href="/leathers"
-            className="px-6 py-2 bg-black text-white rounded-full"
+            className="px-6 py-2 bg-primary text-primary-foreground rounded-full"
           >
             Вернуться к коже
           </Link>
@@ -138,16 +138,16 @@ export default async function LeatherDetailPage({
       <div className="mt-20 pt-8">
         {/* Breadcrumb */}
         <div className="container mx-auto px-8 mb-8">
-          <div className="text-sm text-gray-500">
-            <Link href="/" className="hover:text-black">
+          <div className="text-sm text-muted-foreground">
+            <Link href="/" className="hover:text-foreground">
               Главная
             </Link>
             <span className="mx-2">/</span>
-            <Link href="/leathers" className="hover:text-black">
+            <Link href="/leathers" className="hover:text-foreground">
               Кожи
             </Link>
             <span className="mx-2">/</span>
-            <span className="text-black">{product.name}</span>
+            <span className="text-foreground">{product.name}</span>
           </div>
         </div>
 
@@ -155,7 +155,7 @@ export default async function LeatherDetailPage({
           <div className="grid grid-cols-1 lg:grid-cols-2 gap-12">
             {/* Product Images */}
             <div className="space-y-4">
-              <div className="relative aspect-square rounded-md overflow-hidden border border-gray-200">
+              <div className="relative aspect-square rounded-md overflow-hidden border border-border">
                 <Image
                   src={product.images[0]}
                   alt={product.name}
@@ -169,7 +169,7 @@ export default async function LeatherDetailPage({
                 {product.images.slice(1).map((image, index) => (
                   <div
                     key={index}
-                    className="relative aspect-square rounded-md overflow-hidden border border-gray-200"
+                    className="relative aspect-square rounded-md overflow-hidden border border-border"
                   >
                     <Image
                       src={image}
@@ -185,7 +185,7 @@ export default async function LeatherDetailPage({
             {/* Product Details */}
             <div>
               <h1 className="text-4xl font-bold mb-2">{product.name}</h1>
-              <p className="text-lg text-gray-600 mb-6">
+              <p className="text-lg text-muted-foreground mb-6">
                 Коллекция {product.collection}
               </p>
 
@@ -195,42 +195,42 @@ export default async function LeatherDetailPage({
 
               <div className="grid grid-cols-2 gap-x-8 gap-y-6 mb-10">
                 <div>
-                  <h3 className="text-sm font-medium text-gray-500 mb-2">
+                  <h3 className="text-sm font-medium text-muted-foreground mb-2">
                     ТИП
                   </h3>
                   <p>{product.type}</p>
                 </div>
 
                 <div>
-                  <h3 className="text-sm font-medium text-gray-500 mb-2">
+                  <h3 className="text-sm font-medium text-muted-foreground mb-2">
                     ОТДЕЛКА
                   </h3>
                   <p>{product.finish}</p>
                 </div>
 
                 <div>
-                  <h3 className="text-sm font-medium text-gray-500 mb-2">
+                  <h3 className="text-sm font-medium text-muted-foreground mb-2">
                     ОБРАБОТКА
                   </h3>
                   <p>{product.treatment}</p>
                 </div>
 
                 <div>
-                  <h3 className="text-sm font-medium text-gray-500 mb-2">
+                  <h3 className="text-sm font-medium text-muted-foreground mb-2">
                     ТОЛЩИНА
                   </h3>
                   <p>{product.thickness}</p>
                 </div>
 
                 <div className="col-span-2">
-                  <h3 className="text-sm font-medium text-gray-500 mb-2">
+                  <h3 className="text-sm font-medium text-muted-foreground mb-2">
                     ПРИМЕНЕНИЕ
                   </h3>
                   <div className="flex flex-wrap gap-2">
                     {product.applications.map((app, index) => (
                       <span
                         key={index}
-                        className="px-3 py-1 bg-gray-100 rounded-full text-sm"
+                        className="px-3 py-1 bg-muted rounded-full text-sm"
                       >
                         {app}
                       </span>
@@ -239,14 +239,14 @@ export default async function LeatherDetailPage({
                 </div>
 
                 <div className="col-span-2">
-                  <h3 className="text-sm font-medium text-gray-500 mb-2">
+                  <h3 className="text-sm font-medium text-muted-foreground mb-2">
                     ДОСТУПНЫЕ ЦВЕТА
                   </h3>
                   <div className="flex flex-wrap gap-2">
                     {product.colors.map((color, index) => (
                       <span
                         key={index}
-                        className="px-3 py-1 bg-gray-100 rounded-full text-sm"
+                        className="px-3 py-1 bg-muted rounded-full text-sm"
                       >
                         {color}
                       </span>
@@ -256,23 +256,23 @@ export default async function LeatherDetailPage({
               </div>
 
               {/* Sustainability Info */}
-              <div className="bg-gray-50 p-6 rounded-md mb-8">
+              <div className="bg-secondary p-6 rounded-md mb-8">
                 <h3 className="text-lg font-medium mb-2">Устойчивость</h3>
-                <p className="text-gray-700">{product.sustainability}</p>
+                <p className="text-muted-foreground">{product.sustainability}</p>
               </div>
 
               {/* CTA Buttons */}
               <div className="flex flex-wrap gap-4">
                 <Link
                   href="/contact"
-                  className="px-6 py-3 bg-black text-white rounded-full"
+                  className="px-6 py-3 bg-primary text-primary-foreground rounded-full"
                 >
                   Запросить образцы
                 </Link>
 
                 <Link
                   href="/contact"
-                  className="px-6 py-3 border border-black rounded-full"
+                  className="px-6 py-3 border border-primary rounded-full"
                 >
                   Технические характеристики
                 </Link>
@@ -282,7 +282,7 @@ export default async function LeatherDetailPage({
         </div>
 
         {/* Related Products */}
-        <section className="mt-20 py-16 px-8 bg-gray-50">
+        <section className="mt-20 py-16 px-8 bg-secondary">
           <div className="container mx-auto">
             <h2 className="text-3xl font-bold mb-10">
               Вам также может понравиться
@@ -305,7 +305,7 @@ export default async function LeatherDetailPage({
                   <Link
                     key={relatedProduct.id}
                     href={`/leathers/${relatedProduct.id}`}
-                    className="group border border-gray-200 bg-white rounded-md overflow-hidden hover:shadow-md transition-shadow"
+                    className="group border border-border bg-background rounded-md overflow-hidden hover:shadow-md transition-shadow"
                   >
                     <div className="relative aspect-square">
                       <Image
@@ -319,7 +319,7 @@ export default async function LeatherDetailPage({
                       <h3 className="text-lg font-bold group-hover:text-accent transition-colors">
                         {relatedProduct.name}
                       </h3>
-                      <p className="text-sm text-gray-500">
+                      <p className="text-sm text-muted-foreground">
                         Коллекция {relatedProduct.collection}
                       </p>
                     </div>

--- a/src/app/leathers/page.tsx
+++ b/src/app/leathers/page.tsx
@@ -64,7 +64,7 @@ export default function LeathersPage() {
   return (
     <MainLayout>
       {/* Hero Section */}
-      <section className="relative w-full h-[40vh] bg-black text-white mt-20">
+      <section className="relative w-full h-[40vh] bg-primary text-primary-foreground mt-20">
         <div className="absolute inset-0 z-0">
           <Image
             src="https://ext.same-assets.com/1118492138/3442149313.jpeg"
@@ -87,17 +87,17 @@ export default function LeathersPage() {
       </section>
 
       {/* Filters Section */}
-      <section className="py-8 px-8 bg-gray-50 border-b border-gray-200">
+      <section className="py-8 px-8 bg-secondary border-b border-border">
         <div className="max-w-7xl mx-auto">
           <div className="flex flex-wrap gap-4 justify-between items-center">
             <div className="flex flex-wrap gap-4">
-              <select className="px-4 py-2 border border-gray-300 rounded-md bg-white">
+              <select className="px-4 py-2 border border-border rounded-md bg-background">
                 <option>Все коллекции</option>
                 <option>Весна-Лето 27</option>
                 <option>Осень-Зима 26</option>
               </select>
 
-              <select className="px-4 py-2 border border-gray-300 rounded-md bg-white">
+              <select className="px-4 py-2 border border-border rounded-md bg-background">
                 <option>Все типы</option>
                 <option>Гладкая</option>
                 <option>Нубук</option>
@@ -105,7 +105,7 @@ export default function LeathersPage() {
                 <option>Подкладочная</option>
               </select>
 
-              <select className="px-4 py-2 border border-gray-300 rounded-md bg-white">
+              <select className="px-4 py-2 border border-border rounded-md bg-background">
                 <option>Все обработки</option>
                 <option>Анилиновая</option>
                 <option>Полуанилиновая</option>
@@ -115,8 +115,8 @@ export default function LeathersPage() {
             </div>
 
             <div className="flex items-center gap-2">
-              <span className="text-sm text-gray-500">Сортировать:</span>
-              <select className="px-4 py-2 border border-gray-300 rounded-md bg-white">
+              <span className="text-sm text-muted-foreground">Сортировать:</span>
+              <select className="px-4 py-2 border border-border rounded-md bg-background">
                 <option>Новинки</option>
                 <option>Название (А-Я)</option>
                 <option>Коллекция</option>
@@ -134,7 +134,7 @@ export default function LeathersPage() {
               <Link
                 key={product.id}
                 href={`/leathers/${product.id}`}
-                className="group border border-gray-200 rounded-md overflow-hidden hover:shadow-md transition-shadow"
+                className="group border border-border rounded-md overflow-hidden hover:shadow-md transition-shadow"
               >
                 <div className="relative aspect-square">
                   <Image
@@ -148,25 +148,25 @@ export default function LeathersPage() {
                   <h3 className="text-xl font-bold group-hover:text-accent transition-colors">
                     {product.name}
                   </h3>
-                  <p className="text-sm text-gray-500">
+                  <p className="text-sm text-muted-foreground">
                     Коллекция {product.collection}
                   </p>
 
                   <div className="mt-4 grid grid-cols-2 gap-x-4 gap-y-2">
                     <div>
-                      <span className="text-xs font-medium text-gray-500">
+                      <span className="text-xs font-medium text-muted-foreground">
                         ТИП
                       </span>
                       <p className="text-sm">{product.type}</p>
                     </div>
                     <div>
-                      <span className="text-xs font-medium text-gray-500">
+                      <span className="text-xs font-medium text-muted-foreground">
                         ОТДЕЛКА
                       </span>
                       <p className="text-sm">{product.finish}</p>
                     </div>
                     <div>
-                      <span className="text-xs font-medium text-gray-500">
+                      <span className="text-xs font-medium text-muted-foreground">
                         ОБРАБОТКА
                       </span>
                       <p className="text-sm">{product.treatment}</p>
@@ -180,7 +180,7 @@ export default function LeathersPage() {
       </section>
 
       {/* Request Samples CTA */}
-      <section className="py-16 px-8 bg-gray-100">
+      <section className="py-16 px-8 bg-muted">
         <div className="max-w-4xl mx-auto text-center">
           <h2 className="text-3xl font-bold mb-4">Запросить образцы</h2>
           <p className="text-lg mb-8 max-w-2xl mx-auto">
@@ -189,7 +189,7 @@ export default function LeathersPage() {
           </p>
           <Link
             href="/contact"
-            className="px-8 py-3 bg-black text-white rounded-full text-lg inline-block"
+            className="px-8 py-3 bg-primary text-primary-foreground rounded-full text-lg inline-block"
           >
             Свяжитесь с нами
           </Link>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -92,7 +92,7 @@ export default function Home() {
   return (
     <MainLayout transparentHeader={true}>
       {/* Hero Section */}
-      <section className="relative w-full h-screen bg-white text-gray-900 overflow-hidden">
+      <section className="relative w-full h-screen bg-background text-foreground overflow-hidden">
         <AnimatedSection speed={0.3} className="absolute inset-0 z-0">
           <Image
             src="https://ext.same-assets.com/1118492138/3414069527.jpeg"
@@ -135,12 +135,12 @@ export default function Home() {
                     style={{ objectFit: "cover" }}
                     className="transition-transform duration-500 group-hover:scale-110"
                   />
-                  <div className="absolute inset-0 bg-gradient-to-t from-white/80 to-transparent flex items-end p-6">
+                  <div className="absolute inset-0 bg-gradient-to-t from-background/80 to-transparent flex items-end p-6">
                     <div>
-                      <span className="text-gray-900 font-medium text-xl mb-1 block">
+                      <span className="text-foreground font-medium text-xl mb-1 block">
                         О GRANDTEX
                       </span>
-                      <p className="text-gray-700 text-sm">
+                      <p className="text-muted-foreground text-sm">
                         Узнайте нашу историю, ценности и видение
                       </p>
                     </div>
@@ -159,12 +159,12 @@ export default function Home() {
                     style={{ objectFit: "cover" }}
                     className="transition-transform duration-500 group-hover:scale-110"
                   />
-                  <div className="absolute inset-0 bg-gradient-to-t from-white/80 to-transparent flex items-end p-6">
+                  <div className="absolute inset-0 bg-gradient-to-t from-background/80 to-transparent flex items-end p-6">
                     <div>
-                      <span className="text-gray-900 font-medium text-xl mb-1 block">
+                      <span className="text-foreground font-medium text-xl mb-1 block">
                         Наши кожевенные заводы
                       </span>
-                      <p className="text-gray-700 text-sm">
+                      <p className="text-muted-foreground text-sm">
                         Ознакомьтесь с нашими передовыми производствами
                       </p>
                     </div>
@@ -175,7 +175,7 @@ export default function Home() {
             <div className="mt-8 flex justify-center md:justify-start">
               <Link
                 href="/leathers"
-                className="px-8 py-3 border border-black text-black rounded-full inline-block hover:bg-black hover:text-white transition-colors duration-300"
+                className="px-8 py-3 border border-primary text-foreground rounded-full inline-block hover:bg-primary hover:text-primary-foreground transition-colors duration-300"
               >
                 Исследуйте наши кожи
               </Link>
@@ -194,7 +194,7 @@ export default function Home() {
           >
             <path
               d="M12 5V19M12 19L5 12M12 19L19 12"
-              stroke="black"
+              stroke="currentColor"
               strokeWidth="2"
               strokeLinecap="round"
               strokeLinejoin="round"
@@ -204,11 +204,11 @@ export default function Home() {
       </section>
 
       {/* Leathers Section */}
-      <section className="w-full py-24 px-8 bg-white">
+      <section className="w-full py-24 px-8 bg-background">
         <div className="max-w-7xl mx-auto">
           <AnimatedSection className="text-center mb-16">
             <h2 className="text-4xl font-bold mb-4">Последняя коллекция</h2>
-            <p className="text-xl text-gray-600 max-w-3xl mx-auto">
+            <p className="text-xl text-muted-foreground max-w-3xl mx-auto">
               Откройте нашу коллекцию Весна-Лето 27, включающую премиальные
               кожи, созданные для универсальности и высокой производительности.
             </p>
@@ -219,7 +219,7 @@ export default function Home() {
               <AnimatedSection key={product.id} delay={index * 0.15}>
                 <Link
                   href={`/leathers/${product.id}`}
-                  className="group block bg-white border border-gray-200 rounded-lg overflow-hidden hover:shadow-lg transition-all duration-300 transform hover:-translate-y-1"
+                  className="group block bg-background border border-border rounded-lg overflow-hidden hover:shadow-lg transition-all duration-300 transform hover:-translate-y-1"
                 >
                   <div className="relative aspect-square overflow-hidden">
                     <Image
@@ -234,20 +234,20 @@ export default function Home() {
                     <h3 className="text-xl font-bold group-hover:text-accent transition-colors">
                       {product.name}
                     </h3>
-                    <p className="text-sm text-gray-500 mt-1">
+                    <p className="text-sm text-muted-foreground mt-1">
                       {product.collection}
                     </p>
                     <div className="mt-4 space-y-1">
                       <div className="flex justify-between">
-                        <span className="text-sm text-gray-500">Тип</span>
+                        <span className="text-sm text-muted-foreground">Тип</span>
                         <span className="text-sm">{product.type}</span>
                       </div>
                       <div className="flex justify-between">
-                        <span className="text-sm text-gray-500">Отделка</span>
+                        <span className="text-sm text-muted-foreground">Отделка</span>
                         <span className="text-sm">{product.finish}</span>
                       </div>
                       <div className="flex justify-between">
-                        <span className="text-sm text-gray-500">Обработка</span>
+                        <span className="text-sm text-muted-foreground">Обработка</span>
                         <span className="text-sm">{product.treatment}</span>
                       </div>
                     </div>
@@ -257,7 +257,7 @@ export default function Home() {
             ))}
           </div>
           <AnimatedSection delay={0.6} className="mt-16 text-center">
-            <p className="mb-8 text-gray-700 max-w-3xl mx-auto">
+            <p className="mb-8 text-muted-foreground max-w-3xl mx-auto">
               От спортзала до офиса, коллекция SS27 отражает глубину и широту
               того, что GRANDTEX умеет лучше всего — создавать универсальные
               кожи, которые масштабируются под ваши нужды. В рамках нашего
@@ -267,7 +267,7 @@ export default function Home() {
             </p>
             <Link
               href="/collections/spring-summer-2027"
-              className="px-8 py-3 bg-black text-white rounded-full inline-block hover:bg-gray-900 transition-colors"
+              className="px-8 py-3 bg-primary text-primary-foreground rounded-full inline-block hover:bg-primary/80 transition-colors"
             >
               Откройте коллекцию
             </Link>
@@ -276,7 +276,7 @@ export default function Home() {
       </section>
 
       {/* Sustainability Section */}
-      <section className="w-full py-24 px-8 bg-gray-50 relative overflow-hidden opacity-0 animate-fade-in-scroll">
+      <section className="w-full py-24 px-8 bg-secondary relative overflow-hidden opacity-0 animate-fade-in-scroll">
         <div className="absolute inset-0 z-0 opacity-10">
           <Image
             src="https://ext.same-assets.com/1118492138/180971912.jpeg"
@@ -290,7 +290,7 @@ export default function Home() {
           <div className="grid grid-cols-1 lg:grid-cols-2 gap-16">
             <div className="opacity-0 animate-fade-in-scroll">
               <h2 className="text-4xl font-bold mb-6">Устойчивость</h2>
-              <p className="text-lg text-gray-700 mb-8">
+              <p className="text-lg text-muted-foreground mb-8">
                 Устойчивость всегда была в основе бизнеса GRANDTEX. Мы пошли
                 дальше и определили цели по четырём направлениям: Операционное
                 совершенство, Циркулярность, Климатические действия и Социальное
@@ -301,18 +301,18 @@ export default function Home() {
                 {sustainabilityPillars.map((pillar, index) => (
                   <div
                     key={pillar.title}
-                    className="bg-white p-6 rounded-lg shadow-sm transform transition-transform duration-300 hover:scale-[1.03] opacity-0 animate-fade-in-scroll"
+                    className="bg-background p-6 rounded-lg shadow-sm transform transition-transform duration-300 hover:scale-[1.03] opacity-0 animate-fade-in-scroll"
                     style={{ animationDelay: `${index * 150 + 300}ms` }}
                   >
                     <h3 className="text-lg font-bold mb-2">{pillar.title}</h3>
-                    <p className="text-gray-600">{pillar.description}</p>
+                    <p className="text-muted-foreground">{pillar.description}</p>
                   </div>
                 ))}
               </div>
 
               <Link
                 href="/sustainability"
-                className="px-8 py-3 bg-black text-white rounded-full inline-block hover:bg-gray-900 transition-colors"
+                className="px-8 py-3 bg-primary text-primary-foreground rounded-full inline-block hover:bg-primary/80 transition-colors"
               >
                 Узнайте больше о наших инициативах
               </Link>
@@ -330,9 +330,9 @@ export default function Home() {
                   style={{ objectFit: "cover" }}
                 />
               </div>
-              <div className="absolute -bottom-8 -left-8 w-2/3 bg-white p-6 rounded-lg shadow-lg transform transition-transform duration-300 hover:scale-[1.02]">
+              <div className="absolute -bottom-8 -left-8 w-2/3 bg-background p-6 rounded-lg shadow-lg transform transition-transform duration-300 hover:scale-[1.02]">
                 <h3 className="text-xl font-bold mb-2">Наша приверженность</h3>
-                <p className="text-gray-700">
+                <p className="text-muted-foreground">
                   К 2030 году мы стремимся сократить потребление воды на 50%,
                   достичь углеродной нейтральности и обеспечить переработку или
                   повторное использование 100% кожаных отходов.
@@ -344,13 +344,13 @@ export default function Home() {
       </section>
 
       {/* Brands Section */}
-      <section className="w-full py-24 px-8 bg-white opacity-0 animate-fade-in-scroll">
+      <section className="w-full py-24 px-8 bg-background opacity-0 animate-fade-in-scroll">
         <div className="max-w-7xl mx-auto">
           <div className="text-center mb-16 opacity-0 animate-fade-in-scroll">
             <h2 className="text-4xl font-bold mb-4">
               Нам доверяют мировые бренды
             </h2>
-            <p className="text-xl text-gray-600 max-w-3xl mx-auto">
+            <p className="text-xl text-muted-foreground max-w-3xl mx-auto">
               Мы сотрудничаем с брендами любого масштаба, сочетая мастерство
               мирового уровня с персонализированным сервисом для создания
               исключительных кожаных продуктов.
@@ -361,7 +361,7 @@ export default function Home() {
             {featuredBrands.map((brand, index) => (
               <div
                 key={brand.name}
-                className="aspect-square relative bg-gray-50 rounded-lg overflow-hidden group hover:shadow-md transition-all opacity-0 animate-fade-in-scroll"
+                className="aspect-square relative bg-secondary rounded-lg overflow-hidden group hover:shadow-md transition-all opacity-0 animate-fade-in-scroll"
                 style={{ animationDelay: `${index * 150 + 300}ms` }}
               >
                 <Image
@@ -371,15 +371,15 @@ export default function Home() {
                   style={{ objectFit: "cover", opacity: 0.8 }}
                   className="transition-transform duration-500 group-hover:scale-110"
                 />
-                <div className="absolute inset-0 flex items-end p-4 bg-gradient-to-t from-black/60 to-transparent opacity-0 group-hover:opacity-100 transition-opacity">
-                  <span className="text-white font-medium">{brand.name}</span>
+                <div className="absolute inset-0 flex items-end p-4 bg-gradient-to-t from-primary/60 to-transparent opacity-0 group-hover:opacity-100 transition-opacity">
+                  <span className="text-primary-foreground font-medium">{brand.name}</span>
                 </div>
               </div>
             ))}
           </div>
 
           <div
-            className="mt-20 bg-gray-900 rounded-2xl p-12 text-white text-center opacity-0 animate-fade-in-scroll"
+            className="mt-20 bg-primary rounded-2xl p-12 text-primary-foreground text-center opacity-0 animate-fade-in-scroll"
             style={{ animationDelay: "800ms" }}
           >
             <h3 className="text-3xl font-bold mb-6">Готовы начать?</h3>
@@ -389,7 +389,7 @@ export default function Home() {
             </p>
             <Link
               href="/contact"
-              className="px-8 py-4 bg-white text-gray-900 rounded-full text-lg font-medium inline-block hover:bg-gray-100 transition-colors"
+              className="px-8 py-4 bg-background text-foreground rounded-full text-lg font-medium inline-block hover:bg-muted transition-colors"
             >
               Свяжитесь с нами сегодня
             </Link>

--- a/src/app/sustainability/page.tsx
+++ b/src/app/sustainability/page.tsx
@@ -6,7 +6,7 @@ export default function SustainabilityPage() {
   return (
     <MainLayout>
       {/* Hero Section */}
-      <section className="relative w-full h-[60vh] bg-black text-white mt-20">
+      <section className="relative w-full h-[60vh] bg-primary text-primary-foreground mt-20">
         <div className="absolute inset-0 z-0">
           <Image
             src="https://ext.same-assets.com/1118492138/180971912.jpeg"
@@ -54,7 +54,7 @@ export default function SustainabilityPage() {
       </section>
 
       {/* Pillars Section */}
-      <section id="operational-excellence" className="py-16 px-8 bg-gray-50">
+      <section id="operational-excellence" className="py-16 px-8 bg-secondary">
         <div className="max-w-4xl mx-auto">
           <h2 className="text-3xl font-bold mb-8">Операционное совершенство</h2>
 
@@ -135,7 +135,7 @@ export default function SustainabilityPage() {
         </div>
       </section>
 
-      <section id="climate-action" className="py-16 px-8 bg-gray-50">
+      <section id="climate-action" className="py-16 px-8 bg-secondary">
         <div className="max-w-4xl mx-auto">
           <h2 className="text-3xl font-bold mb-8">Климатические действия</h2>
 
@@ -213,23 +213,23 @@ export default function SustainabilityPage() {
       </section>
 
       {/* Reports Section */}
-      <section className="py-16 px-8 bg-gray-100">
+      <section className="py-16 px-8 bg-muted">
         <div className="max-w-4xl mx-auto">
           <h2 className="text-3xl font-bold mb-8">Отчёты по устойчивости</h2>
 
           <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
             {[2025, 2024, 2023].map((year) => (
-              <div key={year} className="bg-white p-6 rounded-lg shadow-sm">
+              <div key={year} className="bg-background p-6 rounded-lg shadow-sm">
                 <h3 className="text-xl font-bold mb-2">
                   Отчёт по устойчивости за {year} год
                 </h3>
-                <p className="text-gray-600 mb-4">
+                <p className="text-muted-foreground mb-4">
                   Наш ежегодный отчёт, описывающий усилия в области
                   устойчивости, достижения и цели.
                 </p>
                 <Link
                   href="#"
-                  className="text-black font-medium hover:underline"
+                  className="text-foreground font-medium hover:underline"
                 >
                   Скачать PDF
                 </Link>
@@ -251,7 +251,7 @@ export default function SustainabilityPage() {
           </p>
           <Link
             href="/contact"
-            className="px-8 py-3 bg-black text-white rounded-full text-lg inline-block"
+            className="px-8 py-3 bg-primary text-primary-foreground rounded-full text-lg inline-block"
           >
             Свяжитесь с нами
           </Link>

--- a/src/app/tanneries/page.tsx
+++ b/src/app/tanneries/page.tsx
@@ -51,7 +51,7 @@ export default function TanneriesPage() {
   return (
     <MainLayout>
       {/* Hero Section */}
-      <section className="relative w-full h-[50vh] bg-black text-white mt-20">
+      <section className="relative w-full h-[50vh] bg-primary text-primary-foreground mt-20">
         <div className="absolute inset-0 z-0">
           <Image
             src="https://ext.same-assets.com/1118492138/3036160331.jpeg"
@@ -97,21 +97,21 @@ export default function TanneriesPage() {
           </div>
 
           <div className="grid grid-cols-1 md:grid-cols-3 gap-8 text-center">
-            <div className="bg-gray-50 p-8 rounded-lg">
+            <div className="bg-secondary p-8 rounded-lg">
               <div className="text-4xl font-bold text-accent mb-2">14M+</div>
-              <p className="text-gray-700">
+              <p className="text-muted-foreground">
                 Квадратных футов кожи производится ежегодно
               </p>
             </div>
-            <div className="bg-gray-50 p-8 rounded-lg">
+            <div className="bg-secondary p-8 rounded-lg">
               <div className="text-4xl font-bold text-accent mb-2">600+</div>
-              <p className="text-gray-700">
+              <p className="text-muted-foreground">
                 Квалифицированных сотрудников на предприятиях
               </p>
             </div>
-            <div className="bg-gray-50 p-8 rounded-lg">
+            <div className="bg-secondary p-8 rounded-lg">
               <div className="text-4xl font-bold text-accent mb-2">20+</div>
-              <p className="text-gray-700">
+              <p className="text-muted-foreground">
                 Лет производственного совершенства
               </p>
             </div>
@@ -124,13 +124,13 @@ export default function TanneriesPage() {
         <section
           key={tannery.id}
           id={tannery.id}
-          className={`py-16 px-8 ${index % 2 === 0 ? "bg-white" : "bg-gray-50"}`}
+          className={`py-16 px-8 ${index % 2 === 0 ? "bg-background" : "bg-secondary"}`}
         >
           <div className="max-w-6xl mx-auto">
             <div className="grid grid-cols-1 lg:grid-cols-2 gap-12">
               <div className={`${index % 2 === 1 ? "order-2" : ""}`}>
                 <h2 className="text-3xl font-bold mb-4">{tannery.name}</h2>
-                <p className="text-xl text-gray-600 mb-6">{tannery.location}</p>
+                <p className="text-xl text-muted-foreground mb-6">{tannery.location}</p>
 
                 <div className="prose prose-lg max-w-none mb-8">
                   <p>{tannery.description}</p>
@@ -139,17 +139,17 @@ export default function TanneriesPage() {
                 <div className="grid grid-cols-2 gap-6 mb-8">
                   <div>
                     <h3 className="text-lg font-bold mb-2">Основан</h3>
-                    <p className="text-gray-700">{tannery.established}</p>
+                    <p className="text-muted-foreground">{tannery.established}</p>
                   </div>
                   <div>
                     <h3 className="text-lg font-bold mb-2">
                       Размер предприятия
                     </h3>
-                    <p className="text-gray-700">{tannery.size}</p>
+                    <p className="text-muted-foreground">{tannery.size}</p>
                   </div>
                   <div>
                     <h3 className="text-lg font-bold mb-2">Годовая мощность</h3>
-                    <p className="text-gray-700">{tannery.capacity}</p>
+                    <p className="text-muted-foreground">{tannery.capacity}</p>
                   </div>
                   <div>
                     <h3 className="text-lg font-bold mb-2">Сертификаты</h3>
@@ -157,7 +157,7 @@ export default function TanneriesPage() {
                       {tannery.certifications.map((cert, i) => (
                         <span
                           key={i}
-                          className="inline-block px-3 py-1 bg-gray-100 rounded-full text-sm"
+                          className="inline-block px-3 py-1 bg-muted rounded-full text-sm"
                         >
                           {cert}
                         </span>
@@ -166,20 +166,20 @@ export default function TanneriesPage() {
                   </div>
                 </div>
 
-                <div className="bg-gray-50 p-6 rounded-lg mb-8 border-l-4 border-accent">
+                <div className="bg-secondary p-6 rounded-lg mb-8 border-l-4 border-accent">
                   <h3 className="text-lg font-bold mb-2">Специализация</h3>
-                  <ul className="list-disc pl-5 text-gray-700 space-y-1">
+                  <ul className="list-disc pl-5 text-muted-foreground space-y-1">
                     {tannery.specialties.map((specialty, i) => (
                       <li key={i}>{specialty}</li>
                     ))}
                   </ul>
                 </div>
 
-                <div className="bg-gray-50 p-6 rounded-lg border-l-4 border-green-500">
+                <div className="bg-secondary p-6 rounded-lg border-l-4 border-accent">
                   <h3 className="text-lg font-bold mb-2">
                     Инициативы устойчивости
                   </h3>
-                  <p className="text-gray-700">{tannery.sustainability}</p>
+                  <p className="text-muted-foreground">{tannery.sustainability}</p>
                 </div>
               </div>
 
@@ -215,7 +215,7 @@ export default function TanneriesPage() {
       ))}
 
       {/* Manufacturing Process */}
-      <section className="py-16 px-8 bg-gray-900 text-white">
+      <section className="py-16 px-8 bg-primary text-primary-foreground">
         <div className="max-w-6xl mx-auto">
           <h2 className="text-3xl font-bold mb-12 text-center">
             Наш производственный процесс
@@ -277,10 +277,10 @@ export default function TanneriesPage() {
                   {step.step}
                 </div>
                 <h3 className="text-xl font-bold mb-2">{step.title}</h3>
-                <p className="text-gray-300">{step.description}</p>
+                <p className="text-muted-foreground">{step.description}</p>
 
                 {step.step < 8 && (
-                  <div className="hidden md:block absolute top-6 left-12 w-full h-px bg-gray-700"></div>
+                  <div className="hidden md:block absolute top-6 left-12 w-full h-px bg-muted"></div>
                 )}
               </div>
             ))}
@@ -289,7 +289,7 @@ export default function TanneriesPage() {
       </section>
 
       {/* Quality Assurance */}
-      <section className="py-16 px-8 bg-white">
+      <section className="py-16 px-8 bg-background">
         <div className="max-w-5xl mx-auto">
           <h2 className="text-3xl font-bold mb-12 text-center">
             Гарантия качества
@@ -297,7 +297,7 @@ export default function TanneriesPage() {
 
           <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
             <div className="text-center">
-              <div className="w-20 h-20 bg-gray-100 rounded-full mx-auto mb-4 flex items-center justify-center">
+              <div className="w-20 h-20 bg-muted rounded-full mx-auto mb-4 flex items-center justify-center">
                 <svg
                   xmlns="http://www.w3.org/2000/svg"
                   width="32"
@@ -313,14 +313,14 @@ export default function TanneriesPage() {
                 </svg>
               </div>
               <h3 className="text-xl font-bold mb-3">Лабораторные испытания</h3>
-              <p className="text-gray-700">
+              <p className="text-muted-foreground">
                 Наши лаборатории проводят строгие испытания физических свойств,
                 химического состава и эксплуатационных характеристик.
               </p>
             </div>
 
             <div className="text-center">
-              <div className="w-20 h-20 bg-gray-100 rounded-full mx-auto mb-4 flex items-center justify-center">
+              <div className="w-20 h-20 bg-muted rounded-full mx-auto mb-4 flex items-center justify-center">
                 <svg
                   xmlns="http://www.w3.org/2000/svg"
                   width="32"
@@ -336,7 +336,7 @@ export default function TanneriesPage() {
                 </svg>
               </div>
               <h3 className="text-xl font-bold mb-3">Стандарты инспекции</h3>
-              <p className="text-gray-700">
+              <p className="text-muted-foreground">
                 Мы соблюдаем строгие протоколы проверки на каждом этапе
                 производства, чтобы обеспечить стабильное качество и выявлять
                 проблемы на ранних стадиях.
@@ -344,7 +344,7 @@ export default function TanneriesPage() {
             </div>
 
             <div className="text-center">
-              <div className="w-20 h-20 bg-gray-100 rounded-full mx-auto mb-4 flex items-center justify-center">
+              <div className="w-20 h-20 bg-muted rounded-full mx-auto mb-4 flex items-center justify-center">
                 <svg
                   xmlns="http://www.w3.org/2000/svg"
                   width="32"
@@ -360,7 +360,7 @@ export default function TanneriesPage() {
                 </svg>
               </div>
               <h3 className="text-xl font-bold mb-3">Сертификация</h3>
-              <p className="text-gray-700">
+              <p className="text-muted-foreground">
                 Наши предприятия сертифицированы в соответствии с международными
                 стандартами управления качеством, экологической эффективности и
                 безопасности.
@@ -371,7 +371,7 @@ export default function TanneriesPage() {
       </section>
 
       {/* Tour CTA */}
-      <section className="py-16 px-8 bg-gray-50">
+      <section className="py-16 px-8 bg-secondary">
         <div className="max-w-4xl mx-auto text-center">
           <h2 className="text-3xl font-bold mb-4">Посетите наши предприятия</h2>
           <p className="text-lg mb-8 max-w-2xl mx-auto">
@@ -381,7 +381,7 @@ export default function TanneriesPage() {
           </p>
           <Link
             href="/contact"
-            className="px-8 py-3 bg-black text-white rounded-full text-lg inline-block hover:bg-gray-900 transition-colors"
+            className="px-8 py-3 bg-primary text-primary-foreground rounded-full text-lg inline-block hover:bg-primary/80 transition-colors"
           >
             Запланировать визит
           </Link>

--- a/src/app/why-grandtex/page.tsx
+++ b/src/app/why-grandtex/page.tsx
@@ -45,7 +45,7 @@ export default function WhyGrandtexPage() {
   return (
     <MainLayout>
       {/* Hero Section */}
-      <section className="relative w-full h-[50vh] bg-black text-white mt-20">
+      <section className="relative w-full h-[50vh] bg-primary text-primary-foreground mt-20">
         <div className="absolute inset-0 z-0">
           <Image
             src="https://ext.same-assets.com/1118492138/2560085916.jpeg"
@@ -96,7 +96,7 @@ export default function WhyGrandtexPage() {
       </section>
 
       {/* Advantages Grid */}
-      <section className="py-16 px-8 bg-gray-50">
+      <section className="py-16 px-8 bg-secondary">
         <div className="max-w-6xl mx-auto">
           <h2 className="text-3xl font-bold mb-12 text-center">
             Преимущества GRANDTEX
@@ -104,10 +104,10 @@ export default function WhyGrandtexPage() {
 
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
             {advantages.map((advantage, index) => (
-              <div key={index} className="bg-white p-8 rounded-lg shadow-sm">
+              <div key={index} className="bg-background p-8 rounded-lg shadow-sm">
                 <div className="text-4xl mb-4">{advantage.icon}</div>
                 <h3 className="text-xl font-bold mb-3">{advantage.title}</h3>
-                <p className="text-gray-700">{advantage.description}</p>
+                <p className="text-muted-foreground">{advantage.description}</p>
               </div>
             ))}
           </div>
@@ -142,7 +142,7 @@ export default function WhyGrandtexPage() {
               <div className="mt-8">
                 <Link
                   href="/about-grandtex"
-                  className="px-6 py-3 border border-black rounded-full inline-block"
+                  className="px-6 py-3 border border-primary rounded-full inline-block"
                 >
                   Meet Our Team
                 </Link>
@@ -164,7 +164,7 @@ export default function WhyGrandtexPage() {
       </section>
 
       {/* Technology & Innovation */}
-      <section className="py-16 px-8 bg-gray-50">
+      <section className="py-16 px-8 bg-secondary">
         <div className="max-w-6xl mx-auto">
           <div className="flex flex-col lg:flex-row gap-12">
             <div className="lg:w-1/2 order-2 lg:order-1">
@@ -205,7 +205,7 @@ export default function WhyGrandtexPage() {
               <div className="mt-8">
                 <Link
                   href="/tanneries"
-                  className="px-6 py-3 border border-black rounded-full inline-block"
+                  className="px-6 py-3 border border-primary rounded-full inline-block"
                 >
                   Исследуйте наши предприятия
                 </Link>
@@ -224,33 +224,33 @@ export default function WhyGrandtexPage() {
 
           <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
             <div className="text-center">
-              <div className="w-20 h-20 bg-accent rounded-full flex items-center justify-center text-white text-2xl mx-auto mb-4">
+              <div className="w-20 h-20 bg-accent rounded-full flex items-center justify-center text-primary-foreground text-2xl mx-auto mb-4">
                 1
               </div>
               <h3 className="text-xl font-bold mb-3">Понимание</h3>
-              <p className="text-gray-700">
+              <p className="text-muted-foreground">
                 Мы уделяем время глубокому пониманию ваших потребностей, задач и
                 видения, формируя основу успешного сотрудничества.
               </p>
             </div>
 
             <div className="text-center">
-              <div className="w-20 h-20 bg-accent rounded-full flex items-center justify-center text-white text-2xl mx-auto mb-4">
+              <div className="w-20 h-20 bg-accent rounded-full flex items-center justify-center text-primary-foreground text-2xl mx-auto mb-4">
                 2
               </div>
               <h3 className="text-xl font-bold mb-3">Сотрудничество</h3>
-              <p className="text-gray-700">
+              <p className="text-muted-foreground">
                 Наша команда тесно работает с вашей, объединяя опыт для
                 разработки решений, соответствующих вашим требованиям.
               </p>
             </div>
 
             <div className="text-center">
-              <div className="w-20 h-20 bg-accent rounded-full flex items-center justify-center text-white text-2xl mx-auto mb-4">
+              <div className="w-20 h-20 bg-accent rounded-full flex items-center justify-center text-primary-foreground text-2xl mx-auto mb-4">
                 3
               </div>
               <h3 className="text-xl font-bold mb-3">Результат</h3>
-              <p className="text-gray-700">
+              <p className="text-muted-foreground">
                 Мы выполняем работу с точностью, предоставляя высококачественные
                 кожи вовремя и согласно спецификациям, обеспечивая надёжную
                 поддержку на всех этапах.
@@ -261,14 +261,14 @@ export default function WhyGrandtexPage() {
       </section>
 
       {/* Testimonials */}
-      <section className="py-16 px-8 bg-gray-900 text-white">
+      <section className="py-16 px-8 bg-primary text-primary-foreground">
         <div className="max-w-6xl mx-auto">
           <h2 className="text-3xl font-bold mb-12 text-center">
             Что говорят наши партнёры
           </h2>
 
           <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
-            <div className="bg-gray-800 p-8 rounded-lg">
+            <div className="bg-muted p-8 rounded-lg">
               <div className="text-2xl text-accent mb-4">"</div>
               <p className="text-lg mb-6">
                 GRANDTEX постоянно поставляет исключительную кожу,
@@ -278,13 +278,13 @@ export default function WhyGrandtexPage() {
               </p>
               <div>
                 <p className="font-bold">Sarah Johnson</p>
-                <p className="text-gray-400">
+                <p className="text-muted-foreground">
                   Директор по материалам, глобальный обувной бренд
                 </p>
               </div>
             </div>
 
-            <div className="bg-gray-800 p-8 rounded-lg">
+            <div className="bg-muted p-8 rounded-lg">
               <div className="text-2xl text-accent mb-4">"</div>
               <p className="text-lg mb-6">
                 Как небольшое производство, мы ценим готовность GRANDTEX
@@ -293,7 +293,7 @@ export default function WhyGrandtexPage() {
               </p>
               <div>
                 <p className="font-bold">Michael Chen</p>
-                <p className="text-gray-400">
+                <p className="text-muted-foreground">
                   Основатель, ремесленные изделия из кожи
                 </p>
               </div>
@@ -314,7 +314,7 @@ export default function WhyGrandtexPage() {
           </p>
           <Link
             href="/contact"
-            className="px-8 py-3 bg-black text-white rounded-full text-lg inline-block"
+            className="px-8 py-3 bg-primary text-primary-foreground rounded-full text-lg inline-block"
           >
             Свяжитесь с нами
           </Link>

--- a/src/components/AudioPlayer.tsx
+++ b/src/components/AudioPlayer.tsx
@@ -102,7 +102,7 @@ export default function AudioPlayer({ tracks, className }: AudioPlayerProps) {
   return (
     <div
       className={cn(
-        "w-full max-w-md p-4 rounded-xl shadow-md bg-white",
+        "w-full max-w-md p-4 rounded-xl shadow-md bg-background",
         className,
       )}
     >
@@ -121,14 +121,14 @@ export default function AudioPlayer({ tracks, className }: AudioPlayerProps) {
         <button
           onClick={handlePrev}
           aria-label="Предыдущий"
-          className="p-2 rounded-full hover:bg-gray-100"
+          className="p-2 rounded-full hover:bg-muted"
         >
           <SkipBack className="h-5 w-5" />
         </button>
         <button
           onClick={togglePlay}
           aria-label={playing ? "Пауза" : "Воспроизвести"}
-          className="p-4 bg-black text-white rounded-full hover:bg-gray-800 transition-colors"
+          className="p-4 bg-primary text-primary-foreground rounded-full hover:bg-primary/80 transition-colors"
         >
           {playing ? (
             <Pause className="h-6 w-6" />
@@ -139,16 +139,16 @@ export default function AudioPlayer({ tracks, className }: AudioPlayerProps) {
         <button
           onClick={handleNext}
           aria-label="Следующий"
-          className="p-2 rounded-full hover:bg-gray-100"
+          className="p-2 rounded-full hover:bg-muted"
         >
           <SkipForward className="h-5 w-5" />
         </button>
       </div>
 
       <div className="mb-4">
-        <motion.div className="h-2 bg-gray-200 rounded">
+        <motion.div className="h-2 bg-muted rounded">
           <motion.div
-            className="h-full bg-black rounded"
+            className="h-full bg-primary rounded"
             style={{ width: `${progress * 100}%` }}
           />
         </motion.div>
@@ -201,8 +201,8 @@ export default function AudioPlayer({ tracks, className }: AudioPlayerProps) {
           <li key={track.src}>
             <button
               className={cn(
-                "w-full text-left p-2 rounded hover:bg-gray-100 transition-colors",
-                idx === current && "bg-gray-200",
+                "w-full text-left p-2 rounded hover:bg-muted transition-colors",
+                idx === current && "bg-muted",
               )}
               onClick={() => {
                 setCurrent(idx);

--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -17,7 +17,7 @@ export default function ThemeToggle({ className }: ThemeToggleProps) {
       onClick={toggle}
       aria-label="Переключить тему"
       className={cn(
-        "p-2 rounded-md transition-colors hover:bg-gray-200 dark:hover:bg-gray-700",
+        "p-2 rounded-md transition-colors hover:bg-muted dark:hover:bg-muted",
         className
       )}
     >

--- a/src/components/layout/CookieConsent.tsx
+++ b/src/components/layout/CookieConsent.tsx
@@ -26,24 +26,24 @@ export default function CookieConsent() {
   if (!isVisible) return null;
 
   return (
-    <div className="fixed bottom-4 left-4 right-4 md:left-auto md:right-4 md:max-w-md bg-white p-4 rounded-md shadow-lg z-50 border border-gray-200">
+    <div className="fixed bottom-4 left-4 right-4 md:left-auto md:right-4 md:max-w-md bg-background p-4 rounded-md shadow-lg z-50 border border-border">
       <p className="text-sm mb-4">
         Этот сайт использует файлы cookie для улучшения вашего опыта.
       </p>
       <div className="flex flex-col sm:flex-row space-y-2 sm:space-y-0 sm:space-x-2">
         <button
           onClick={handleAccept}
-          className="px-4 py-2 bg-black text-white rounded-md text-sm"
+          className="px-4 py-2 bg-primary text-primary-foreground rounded-md text-sm"
         >
           Принять все
         </button>
         <button
           onClick={handleReject}
-          className="px-4 py-2 bg-gray-200 text-black rounded-md text-sm"
+          className="px-4 py-2 bg-muted text-foreground rounded-md text-sm"
         >
           Отклонить все
         </button>
-        <button className="px-4 py-2 bg-gray-100 text-black rounded-md text-sm">
+        <button className="px-4 py-2 bg-muted text-foreground rounded-md text-sm">
           Настроить предпочтения
         </button>
       </div>

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -2,20 +2,20 @@ import Link from "next/link";
 
 export default function Footer() {
   return (
-    <footer className="w-full py-16 px-8 bg-gray-100">
+    <footer className="w-full py-16 px-8 bg-muted">
       <div className="max-w-7xl mx-auto grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8">
         <div>
           <h3 className="font-medium mb-4">Навигация</h3>
           <ul className="space-y-2">
             <li>
-              <Link href="/leathers" className="text-gray-600 hover:text-black">
+              <Link href="/leathers" className="text-muted-foreground hover:text-foreground">
                 Наши кожи
               </Link>
             </li>
             <li>
               <Link
                 href="/emboss-perforation"
-                className="text-gray-600 hover:text-black"
+                className="text-muted-foreground hover:text-foreground"
               >
                 Тиснение и перфорация
               </Link>
@@ -23,7 +23,7 @@ export default function Footer() {
             <li>
               <Link
                 href="/why-grandtex"
-                className="text-gray-600 hover:text-black"
+                className="text-muted-foreground hover:text-foreground"
               >
                 Почему GRANDTEX?
               </Link>
@@ -31,7 +31,7 @@ export default function Footer() {
             <li>
               <Link
                 href="/about-grandtex"
-                className="text-gray-600 hover:text-black"
+                className="text-muted-foreground hover:text-foreground"
               >
                 О компании
               </Link>
@@ -39,13 +39,13 @@ export default function Footer() {
             <li>
               <Link
                 href="/tanneries"
-                className="text-gray-600 hover:text-black"
+                className="text-muted-foreground hover:text-foreground"
               >
                 Кожевенные заводы
               </Link>
             </li>
             <li>
-              <Link href="/contact" className="text-gray-600 hover:text-black">
+              <Link href="/contact" className="text-muted-foreground hover:text-foreground">
                 Контакты
               </Link>
             </li>
@@ -58,7 +58,7 @@ export default function Footer() {
             <li>
               <Link
                 href="/collections/spring-summer-2027"
-                className="text-gray-600 hover:text-black"
+                className="text-muted-foreground hover:text-foreground"
               >
                 Коллекция Весна-Лето 27
               </Link>
@@ -66,7 +66,7 @@ export default function Footer() {
             <li>
               <Link
                 href="/collections/fw26"
-                className="text-gray-600 hover:text-black"
+                className="text-muted-foreground hover:text-foreground"
               >
                 Коллекция Осень-Зима 26
               </Link>
@@ -80,7 +80,7 @@ export default function Footer() {
             <li>
               <Link
                 href="/sustainability"
-                className="text-gray-600 hover:text-black"
+                className="text-muted-foreground hover:text-foreground"
               >
                 Устойчивость
               </Link>
@@ -88,7 +88,7 @@ export default function Footer() {
             <li>
               <Link
                 href="/sustainability#operational-excellence"
-                className="text-gray-600 hover:text-black"
+                className="text-muted-foreground hover:text-foreground"
               >
                 Операционное совершенство
               </Link>
@@ -96,7 +96,7 @@ export default function Footer() {
             <li>
               <Link
                 href="/sustainability#circularity"
-                className="text-gray-600 hover:text-black"
+                className="text-muted-foreground hover:text-foreground"
               >
                 Циркулярность
               </Link>
@@ -104,7 +104,7 @@ export default function Footer() {
             <li>
               <Link
                 href="/sustainability#climate-action"
-                className="text-gray-600 hover:text-black"
+                className="text-muted-foreground hover:text-foreground"
               >
                 Климатические действия
               </Link>
@@ -112,7 +112,7 @@ export default function Footer() {
             <li>
               <Link
                 href="/sustainability#social-impact"
-                className="text-gray-600 hover:text-black"
+                className="text-muted-foreground hover:text-foreground"
               >
                 Социальное воздействие
               </Link>
@@ -126,7 +126,7 @@ export default function Footer() {
             <li>
               <Link
                 href="/highlights"
-                className="text-gray-600 hover:text-black"
+                className="text-muted-foreground hover:text-foreground"
               >
                 Основные моменты
               </Link>
@@ -134,20 +134,20 @@ export default function Footer() {
             <li>
               <Link
                 href="/education"
-                className="text-gray-600 hover:text-black"
+                className="text-muted-foreground hover:text-foreground"
               >
                 Обучение
               </Link>
             </li>
             <li>
-              <Link href="/contact" className="text-gray-600 hover:text-black">
+              <Link href="/contact" className="text-muted-foreground hover:text-foreground">
                 Локации
               </Link>
             </li>
             <li>
               <Link
                 href="/resources"
-                className="text-gray-600 hover:text-black"
+                className="text-muted-foreground hover:text-foreground"
               >
                 Ресурсы
               </Link>
@@ -155,7 +155,7 @@ export default function Footer() {
           </ul>
 
           <div className="mt-8">
-            <p className="text-sm text-gray-600 mb-4">
+            <p className="text-sm text-muted-foreground mb-4">
               Подпишитесь на нашу рассылку, чтобы получать последние новости о
               продуктах, устойчивых инициативах и сервисах.
             </p>
@@ -163,11 +163,11 @@ export default function Footer() {
               <input
                 type="email"
                 placeholder="Электронная почта"
-                className="px-4 py-2 border border-gray-300 rounded-md"
+                className="px-4 py-2 border border-border rounded-md"
               />
               <button
                 type="submit"
-                className="px-4 py-2 bg-black text-white rounded-md"
+                className="px-4 py-2 bg-primary text-primary-foreground rounded-md"
               >
                 Подписаться
               </button>
@@ -176,24 +176,24 @@ export default function Footer() {
         </div>
       </div>
 
-      <div className="max-w-7xl mx-auto mt-16 pt-8 border-t border-gray-300 flex flex-col md:flex-row justify-between items-center">
-        <p className="text-gray-600 text-sm">© 2025 GRANDTEX</p>
+      <div className="max-w-7xl mx-auto mt-16 pt-8 border-t border-border flex flex-col md:flex-row justify-between items-center">
+        <p className="text-muted-foreground text-sm">© 2025 GRANDTEX</p>
         <div className="flex space-x-6 mt-4 md:mt-0">
           <Link
             href="https://www.linkedin.com"
-            className="text-gray-600 hover:text-black"
+            className="text-muted-foreground hover:text-foreground"
           >
             LinkedIn
           </Link>
           <Link
             href="https://www.instagram.com"
-            className="text-gray-600 hover:text-black"
+            className="text-muted-foreground hover:text-foreground"
           >
             Instagram
           </Link>
           <Link
             href="/privacy-policy"
-            className="text-gray-600 hover:text-black"
+            className="text-muted-foreground hover:text-foreground"
           >
             Политика конфиденциальности
           </Link>

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -23,10 +23,10 @@ export default function Header({ transparent = false }) {
   }, []);
 
   const headerClasses = `fixed top-0 left-0 right-0 z-50 transition-all duration-300 ${
-    transparent && !isScrolled ? "bg-transparent" : "bg-white shadow-sm"
+    transparent && !isScrolled ? "bg-transparent" : "bg-background shadow-sm"
   }`;
 
-  const textClasses = transparent && !isScrolled ? "text-white" : "text-black";
+  const textClasses = transparent && !isScrolled ? "text-primary-foreground" : "text-foreground";
 
   const navLinks = [
     {
@@ -136,7 +136,7 @@ export default function Header({ transparent = false }) {
                   grandtex
                 </Link>
                 <button
-                  className="text-gray-500 hover:text-black transition-colors"
+                  className="text-muted-foreground hover:text-foreground transition-colors"
                   onClick={() => setIsMenuOpen(false)}
                 >
                   Закрыть
@@ -165,9 +165,9 @@ export default function Header({ transparent = false }) {
                               <li key={subLink.title}>
                                 <Link
                                   href={subLink.href}
-                                  className={`text-gray-600 hover:text-black transition-colors ${
+                                  className={`text-muted-foreground hover:text-foreground transition-colors ${
                                     pathname === subLink.href
-                                      ? "font-medium text-black"
+                                      ? "font-medium text-foreground"
                                       : ""
                                   }`}
                                 >
@@ -187,8 +187,8 @@ export default function Header({ transparent = false }) {
                               style={{ objectFit: "cover" }}
                               className="transition-transform duration-500 group-hover:scale-110"
                             />
-                            <div className="absolute inset-0 bg-black bg-opacity-30 flex items-end p-4">
-                              <span className="text-white font-medium">
+                            <div className="absolute inset-0 bg-primary bg-opacity-30 flex items-end p-4">
+                              <span className="text-primary-foreground font-medium">
                                 {link.title}
                               </span>
                             </div>
@@ -207,9 +207,9 @@ export default function Header({ transparent = false }) {
                         <li key={link.title}>
                           <Link
                             href={link.href}
-                            className={`text-gray-600 hover:text-black transition-colors ${
+                            className={`text-muted-foreground hover:text-foreground transition-colors ${
                               pathname === link.href
-                                ? "font-medium text-black"
+                                ? "font-medium text-foreground"
                                 : ""
                             }`}
                           >
@@ -227,7 +227,7 @@ export default function Header({ transparent = false }) {
                   <div className="flex space-x-4">
                     <Link
                       href="https://www.linkedin.com"
-                      className="text-gray-500 hover:text-black transition-colors"
+                      className="text-muted-foreground hover:text-foreground transition-colors"
                       target="_blank"
                       rel="noopener noreferrer"
                     >
@@ -235,7 +235,7 @@ export default function Header({ transparent = false }) {
                     </Link>
                     <Link
                       href="https://www.instagram.com"
-                      className="text-gray-500 hover:text-black transition-colors"
+                      className="text-muted-foreground hover:text-foreground transition-colors"
                       target="_blank"
                       rel="noopener noreferrer"
                     >
@@ -244,7 +244,7 @@ export default function Header({ transparent = false }) {
                   </div>
                   <Link
                     href="/contact"
-                    className="px-6 py-2 bg-black text-white rounded-full hover:bg-gray-800 transition-colors"
+                    className="px-6 py-2 bg-primary text-primary-foreground rounded-full hover:bg-primary/80 transition-colors"
                   >
                     Контакты
                   </Link>

--- a/src/components/ui/sheet.tsx
+++ b/src/components/ui/sheet.tsx
@@ -21,7 +21,7 @@ const SheetOverlay = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <SheetPrimitive.Overlay
     className={cn(
-      "fixed inset-0 z-50 bg-black/80 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      "fixed inset-0 z-50 bg-primary/80 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
       className
     )}
     {...props}


### PR DESCRIPTION
## Summary
- tune global CSS variables to new brand palette with warm earthy tones
- switch component styles to use Tailwind color tokens instead of hardcoded values
- align meta theme colors and gradients with the updated palette

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b06e46f3e88325969dfa578606979c