### PR TITLE
Add letter reveal animation and loader component

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,6 +2,7 @@ import Image from "next/image";
 import Link from "next/link";
 import MainLayout from "@/components/layout/MainLayout";
 import AnimatedSection from "@/components/AnimatedSection";
+import LetterLoader from "@/components/LetterLoader";
 
 export default function Home() {
   const latestProducts = [
@@ -91,6 +92,10 @@ export default function Home() {
 
   return (
     <MainLayout transparentHeader={true}>
+      <LetterLoader
+        text="Grandtex Leather"
+        className="mt-8 text-center text-4xl font-bold"
+      />
       {/* Hero Section */}
       <section className="relative w-full h-screen bg-white text-gray-900 overflow-hidden">
         <AnimatedSection speed={0.3} className="absolute inset-0 z-0">

--- a/src/components/LetterLoader.tsx
+++ b/src/components/LetterLoader.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+interface LetterLoaderProps {
+  text: string;
+  className?: string;
+}
+
+export default function LetterLoader({
+  text,
+  className = "",
+}: LetterLoaderProps) {
+  return (
+    <div className={className} aria-label={text}>
+      {text.split("").map((char, index) => (
+        <span
+          key={index}
+          className="inline-block opacity-0 animate-letter-reveal"
+          style={{ animationDelay: `${index * 0.05}s` }}
+        >
+          {char === " " ? "\u00A0" : char}
+        </span>
+      ))}
+    </div>
+  );
+}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -83,6 +83,16 @@ export default {
         "pulse-subtle": {
           "0%, 100%": { opacity: "1" },
           "50%": { opacity: "0.8" }
+        },
+        "letter-reveal": {
+          "0%": {
+            opacity: "0",
+            transform: "translateY(0.5rem)"
+          },
+          "100%": {
+            opacity: "1",
+            transform: "translateY(0)"
+          }
         }
       },
       animation: {
@@ -93,6 +103,7 @@ export default {
         "reveal-delay": "reveal 0.7s ease-in-out 0.3s forwards",
         "float": "float 6s ease-in-out infinite",
         "pulse-subtle": "pulse-subtle 3s ease-in-out infinite",
+        "letter-reveal": "letter-reveal 0.3s ease forwards",
       },
       borderRadius: {
         lg: 'var(--radius)',


### PR DESCRIPTION
## Summary
- add `letter-reveal` keyframes and animation in Tailwind config
- create `LetterLoader` component for staggered text reveal
- render `LetterLoader` on the home page

## Testing
- `bun run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b06e457e4c8325b08aaee0fe5229d4