### PR TITLE
feat: replace sheet menu with overlay

### DIFF
--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,9 +1,8 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import Link from "next/link";
 import Image from "next/image";
-import { Sheet, SheetContent, SheetTrigger } from "@/components/ui/sheet";
 import { usePathname } from "next/navigation";
 import AnimatedSection from "@/components/AnimatedSection";
 import ThemeToggle from "@/components/ThemeToggle";
@@ -12,6 +11,7 @@ export default function Header({ transparent = false }) {
   const [isScrolled, setIsScrolled] = useState(false);
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const pathname = usePathname();
+  const touchStartX = useRef<number | null>(null);
 
   useEffect(() => {
     const handleScroll = () => {
@@ -22,11 +22,36 @@ export default function Header({ transparent = false }) {
     return () => window.removeEventListener("scroll", handleScroll);
   }, []);
 
+  useEffect(() => {
+    const handleTouchStart = (e: TouchEvent) => {
+      if (window.innerWidth >= 768) return;
+      touchStartX.current = e.touches[0].clientX;
+    };
+
+    const handleTouchEnd = (e: TouchEvent) => {
+      if (window.innerWidth >= 768 || touchStartX.current === null) return;
+      const diffX = e.changedTouches[0].clientX - touchStartX.current;
+      if (!isMenuOpen && touchStartX.current < 50 && diffX > 50) {
+        setIsMenuOpen(true);
+      } else if (isMenuOpen && diffX < -50) {
+        setIsMenuOpen(false);
+      }
+    };
+
+    window.addEventListener("touchstart", handleTouchStart);
+    window.addEventListener("touchend", handleTouchEnd);
+    return () => {
+      window.removeEventListener("touchstart", handleTouchStart);
+      window.removeEventListener("touchend", handleTouchEnd);
+    };
+  }, [isMenuOpen]);
+
   const headerClasses = `fixed top-0 left-0 right-0 z-50 transition-all duration-300 ${
-    transparent && !isScrolled ? "bg-transparent" : "bg-white shadow-sm"
+    transparent && !isScrolled ? "bg-transparent" : "bg-background shadow-sm"
   }`;
 
-  const textClasses = transparent && !isScrolled ? "text-white" : "text-black";
+  const textClasses =
+    transparent && !isScrolled ? "text-white" : "text-foreground";
 
   const navLinks = [
     {
@@ -106,155 +131,155 @@ export default function Header({ transparent = false }) {
   ];
 
   return (
-    <header className={headerClasses}>
-      <div className="flex justify-between items-center w-full px-8 py-6">
-        <Link
-          href="/"
-          className={`text-3xl font-bold transition-colors duration-300 ${textClasses}`}
-        >
-          GRANDTEX
-        </Link>
+    <>
+      <header className={headerClasses}>
+        <div className="flex justify-between items-center w-full px-8 py-6">
+          <Link
+            href="/"
+            className={`text-3xl font-bold transition-colors duration-300 ${textClasses}`}
+          >
+            GRANDTEX
+          </Link>
 
-        <div className="flex items-center space-x-4">
-          <ThemeToggle className={textClasses} />
-          <Sheet>
-            <SheetTrigger asChild>
-              <button
-                className={`flex items-center space-x-2 transition-colors duration-300 ${textClasses} hover:opacity-75`}
-                onClick={() => setIsMenuOpen(true)}
-              >
-                <span>Меню</span>
-              </button>
-            </SheetTrigger>
-            <SheetContent
-              side="right"
-              className="w-full sm:max-w-md md:max-w-lg lg:max-w-xl p-0 overflow-y-auto"
+          <div className="flex items-center space-x-4">
+            <ThemeToggle className={textClasses} />
+            <button
+              className={`flex items-center space-x-2 transition-colors duration-300 ${textClasses} hover:opacity-75`}
+              onClick={() => setIsMenuOpen(true)}
             >
-            <AnimatedSection className="h-full flex flex-col">
-              <div className="flex justify-between items-center px-8 py-6 border-b">
-                <Link href="/" className="text-3xl font-bold">
-                  grandtex
-                </Link>
-                <button
-                  className="text-gray-500 hover:text-black transition-colors"
-                  onClick={() => setIsMenuOpen(false)}
-                >
-                  Закрыть
-                </button>
-              </div>
-
-              <div className="flex-1 overflow-auto px-8 py-10">
-                <nav className="space-y-12">
-                  <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
-                    {navLinks.slice(0, 4).map((link, index) => (
-                      <AnimatedSection
-                        key={link.title}
-                        delay={index * 0.1}
-                        className="space-y-4"
-                      >
-                        <Link
-                          href={link.href}
-                          className="flex items-center space-x-2 text-lg font-medium hover:text-accent transition-colors"
-                        >
-                          <span>{link.title}</span>
-                        </Link>
-
-                        {link.subLinks && (
-                          <ul className="space-y-2 ml-4">
-                            {link.subLinks.map((subLink) => (
-                              <li key={subLink.title}>
-                                <Link
-                                  href={subLink.href}
-                                  className={`text-gray-600 hover:text-black transition-colors ${
-                                    pathname === subLink.href
-                                      ? "font-medium text-black"
-                                      : ""
-                                  }`}
-                                >
-                                  {subLink.title}
-                                </Link>
-                              </li>
-                            ))}
-                          </ul>
-                        )}
-
-                        {link.image && (
-                          <div className="relative h-32 rounded-md overflow-hidden mt-4 group">
-                            <Image
-                              src={link.image}
-                              alt={link.title}
-                              fill
-                              style={{ objectFit: "cover" }}
-                              className="transition-transform duration-500 group-hover:scale-110"
-                            />
-                            <div className="absolute inset-0 bg-black bg-opacity-30 flex items-end p-4">
-                              <span className="text-white font-medium">
-                                {link.title}
-                              </span>
-                            </div>
-                          </div>
-                        )}
-                      </AnimatedSection>
-                    ))}
-                  </div>
-
-                  <AnimatedSection delay={0.4} className="space-y-4">
-                    <h2 className="text-lg font-medium">
-                      Дополнительная информация
-                    </h2>
-                    <ul className="grid grid-cols-2 gap-y-2 gap-x-4">
-                      {navLinks.slice(4).map((link) => (
-                        <li key={link.title}>
-                          <Link
-                            href={link.href}
-                            className={`text-gray-600 hover:text-black transition-colors ${
-                              pathname === link.href
-                                ? "font-medium text-black"
-                                : ""
-                            }`}
-                          >
-                            {link.title}
-                          </Link>
-                        </li>
-                      ))}
-                    </ul>
-                  </AnimatedSection>
-                </nav>
-              </div>
-
-              <div className="p-8 border-t">
-                <div className="flex items-center justify-between">
-                  <div className="flex space-x-4">
-                    <Link
-                      href="https://www.linkedin.com"
-                      className="text-gray-500 hover:text-black transition-colors"
-                      target="_blank"
-                      rel="noopener noreferrer"
-                    >
-                      LinkedIn
-                    </Link>
-                    <Link
-                      href="https://www.instagram.com"
-                      className="text-gray-500 hover:text-black transition-colors"
-                      target="_blank"
-                      rel="noopener noreferrer"
-                    >
-                      Instagram
-                    </Link>
-                  </div>
-                  <Link
-                    href="/contact"
-                    className="px-6 py-2 bg-black text-white rounded-full hover:bg-gray-800 transition-colors"
-                  >
-                    Контакты
-                  </Link>
-                </div>
-              </div>
-            </AnimatedSection>
-          </SheetContent>
-          </Sheet>
+              <span>Меню</span>
+            </button>
+          </div>
         </div>
+      </header>
+
+      <div
+        className={`fixed inset-0 z-50 bg-background text-foreground transition-opacity duration-300 ${
+          isMenuOpen ? "opacity-100" : "opacity-0 pointer-events-none"
+        }`}
+      >
+        <AnimatedSection className="h-full flex flex-col">
+          <div className="flex justify-between items-center px-8 py-6 border-b">
+            <Link href="/" className="text-3xl font-bold">
+              grandtex
+            </Link>
+            <button
+              className="text-muted-foreground hover:text-foreground transition-colors"
+              onClick={() => setIsMenuOpen(false)}
+            >
+              Закрыть
+            </button>
+          </div>
+
+          <div className="flex-1 overflow-auto px-8 py-10">
+            <nav className="space-y-12">
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
+                {navLinks.slice(0, 4).map((link, index) => (
+                  <AnimatedSection
+                    key={link.title}
+                    delay={index * 0.1}
+                    className="space-y-4"
+                  >
+                    <Link
+                      href={link.href}
+                      className="flex items-center space-x-2 text-lg font-medium hover:text-accent transition-colors"
+                    >
+                      <span>{link.title}</span>
+                    </Link>
+
+                    {link.subLinks && (
+                      <ul className="space-y-2 ml-4">
+                        {link.subLinks.map((subLink) => (
+                          <li key={subLink.title}>
+                            <Link
+                              href={subLink.href}
+                              className={`text-muted-foreground hover:text-foreground transition-colors ${
+                                pathname === subLink.href
+                                  ? "font-medium text-foreground"
+                                  : ""
+                              }`}
+                            >
+                              {subLink.title}
+                            </Link>
+                          </li>
+                        ))}
+                      </ul>
+                    )}
+
+                    {link.image && (
+                      <div className="relative h-32 rounded-md overflow-hidden mt-4 group">
+                        <Image
+                          src={link.image}
+                          alt={link.title}
+                          fill
+                          style={{ objectFit: "cover" }}
+                          className="transition-transform duration-500 group-hover:scale-110"
+                        />
+                        <div className="absolute inset-0 bg-black/30 flex items-end p-4">
+                          <span className="text-white font-medium">
+                            {link.title}
+                          </span>
+                        </div>
+                      </div>
+                    )}
+                  </AnimatedSection>
+                ))}
+              </div>
+
+              <AnimatedSection delay={0.4} className="space-y-4">
+                <h2 className="text-lg font-medium">
+                  Дополнительная информация
+                </h2>
+                <ul className="grid grid-cols-2 gap-y-2 gap-x-4">
+                  {navLinks.slice(4).map((link) => (
+                    <li key={link.title}>
+                      <Link
+                        href={link.href}
+                        className={`text-muted-foreground hover:text-foreground transition-colors ${
+                          pathname === link.href
+                            ? "font-medium text-foreground"
+                            : ""
+                        }`}
+                      >
+                        {link.title}
+                      </Link>
+                    </li>
+                  ))}
+                </ul>
+              </AnimatedSection>
+            </nav>
+          </div>
+
+          <div className="p-8 border-t">
+            <div className="flex items-center justify-between">
+              <div className="flex space-x-4">
+                <Link
+                  href="https://www.linkedin.com"
+                  className="text-muted-foreground hover:text-foreground transition-colors"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  LinkedIn
+                </Link>
+                <Link
+                  href="https://www.instagram.com"
+                  className="text-muted-foreground hover:text-foreground transition-colors"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  Instagram
+                </Link>
+              </div>
+              <Link
+                href="/contact"
+                className="px-6 py-2 bg-accent text-accent-foreground rounded-full hover:opacity-90 transition-opacity"
+              >
+                Контакты
+              </Link>
+            </div>
+          </div>
+        </AnimatedSection>
       </div>
-    </header>
+    </>
   );
 }


### PR DESCRIPTION
## Summary
- replace sheet sidebar with full screen overlay menu
- apply brand color variables throughout header and navigation
- add touch gesture open/close support for mobile menu

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b06e39c62c8325a927925786db800a