### PR TITLE
refactor: move scroll fade-in to client hook

### DIFF
--- a/src/app/ClientBody.tsx
+++ b/src/app/ClientBody.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect } from "react";
-import { initScrollAnimations, initParallaxEffect } from '../lib/animate';
+import { useScrollFadeIn, initParallaxEffect } from "../lib/animate";
 
 export default function ClientBody({
   children,
@@ -9,10 +9,11 @@ export default function ClientBody({
   children: React.ReactNode;
 }) {
   // Remove any extension-added classes during hydration
+  useScrollFadeIn();
+
   useEffect(() => {
     // This runs only on the client after hydration
     document.body.className = "antialiased font-inter bg-background";
-    initScrollAnimations();
     const cleanupParallax = initParallaxEffect();
   }, []);
 

--- a/src/app/animations.tsx
+++ b/src/app/animations.tsx
@@ -1,13 +1,16 @@
-'use client';
+"use client";
 
-import { useEffect } from 'react';
-import { initScrollAnimations, initParallaxEffect, initProductHoverEffects } from '@/lib/animate';
+import { useEffect } from "react";
+import {
+  useScrollFadeIn,
+  initParallaxEffect,
+  initProductHoverEffects,
+} from "@/lib/animate";
 
 export default function Animations() {
-  useEffect(() => {
-    // Initialize all animations
-    initScrollAnimations();
+  useScrollFadeIn();
 
+  useEffect(() => {
     // Initialize parallax effects
     const cleanupParallax = initParallaxEffect();
 

--- a/src/lib/animate.ts
+++ b/src/lib/animate.ts
@@ -1,68 +1,85 @@
-'use client';
+"use client";
 
-export const initScrollAnimations = () => {
-  if (typeof window === 'undefined') return;
+import { useEffect } from "react";
 
-  const fadeElements = document.querySelectorAll('.animate-fade-in-scroll');
+/**
+ * Hook that reveals elements with the `.animate-fade-in-scroll` class when
+ * they enter the viewport. The initial styles are defined in Tailwind's base
+ * layer; once observed, the element's opacity and transform are updated to
+ * trigger the transition.
+ */
+export const useScrollFadeIn = () => {
+  useEffect(() => {
+    if (typeof window === "undefined") return;
 
-  const observer = new IntersectionObserver((entries) => {
-    entries.forEach(entry => {
-      if (entry.isIntersecting) {
-        entry.target.classList.add('animate-fade-in-up');
-        observer.unobserve(entry.target);
-      }
+    const fadeElements = document.querySelectorAll(".animate-fade-in-scroll");
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          if (entry.isIntersecting) {
+            const el = entry.target as HTMLElement;
+            el.style.opacity = "1";
+            el.style.transform = "translateY(0)";
+            observer.unobserve(entry.target);
+          }
+        });
+      },
+      { threshold: 0.1 },
+    );
+
+    fadeElements.forEach((element) => {
+      observer.observe(element);
     });
-  }, { threshold: 0.1 });
 
-  fadeElements.forEach(element => {
-    observer.observe(element);
-  });
+    return () => observer.disconnect();
+  }, []);
 };
 
 export const initParallaxEffect = () => {
-  if (typeof window === 'undefined') return;
+  if (typeof window === "undefined") return;
 
-  const parallaxElements = document.querySelectorAll('[data-parallax]');
+  const parallaxElements = document.querySelectorAll("[data-parallax]");
 
   const handleScroll = () => {
     const scrollTop = window.scrollY;
 
     parallaxElements.forEach((element) => {
-      const speed = Number(element.getAttribute('data-parallax-speed')) || 0.2;
+      const speed = Number(element.getAttribute("data-parallax-speed")) || 0.2;
       const offset = scrollTop * speed;
       (element as HTMLElement).style.transform = `translateY(${offset}px)`;
     });
   };
 
-  window.addEventListener('scroll', handleScroll);
+  window.addEventListener("scroll", handleScroll);
 
   // Cleanup function
   return () => {
-    window.removeEventListener('scroll', handleScroll);
+    window.removeEventListener("scroll", handleScroll);
   };
 };
 
 export const initProductHoverEffects = () => {
-  if (typeof window === 'undefined') return;
+  if (typeof window === "undefined") return;
 
-  const productCards = document.querySelectorAll('[data-product-card]');
+  const productCards = document.querySelectorAll("[data-product-card]");
 
-  productCards.forEach(card => {
-    card.addEventListener('mouseenter', () => {
-      card.classList.add('scale-[1.02]');
+  productCards.forEach((card) => {
+    card.addEventListener("mouseenter", () => {
+      card.classList.add("scale-[1.02]");
 
-      const image = card.querySelector('[data-product-image]');
+      const image = card.querySelector("[data-product-image]");
       if (image) {
-        image.classList.add('scale-110');
+        image.classList.add("scale-110");
       }
     });
 
-    card.addEventListener('mouseleave', () => {
-      card.classList.remove('scale-[1.02]');
+    card.addEventListener("mouseleave", () => {
+      card.classList.remove("scale-[1.02]");
 
-      const image = card.querySelector('[data-product-image]');
+      const image = card.querySelector("[data-product-image]");
       if (image) {
-        image.classList.remove('scale-110');
+        image.classList.remove("scale-110");
       }
     });
   });

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -120,43 +120,14 @@ export default {
   },
   plugins: [
     require("tailwindcss-animate"),
-    function({ addBase, addComponents }: any) {
+    function({ addBase }: any) {
       addBase({
         '.animate-fade-in-scroll': {
           opacity: '0',
           transform: 'translateY(20px)',
           transition: 'opacity 0.8s ease-in-out, transform 0.8s ease-in-out',
-        }
+        },
       });
-
-      // Add JS to trigger the animation when element is in viewport
-      if (typeof window !== 'undefined') {
-        addComponents({
-          '@global': {
-            'script': {
-              innerHTML: `
-                document.addEventListener('DOMContentLoaded', function() {
-                  const fadeElements = document.querySelectorAll('.animate-fade-in-scroll');
-
-                  const observer = new IntersectionObserver((entries) => {
-                    entries.forEach(entry => {
-                      if (entry.isIntersecting) {
-                        entry.target.style.opacity = '1';
-                        entry.target.style.transform = 'translateY(0)';
-                        observer.unobserve(entry.target);
-                      }
-                    });
-                  }, { threshold: 0.1 });
-
-                  fadeElements.forEach(element => {
-                    observer.observe(element);
-                  });
-                });
-              `
-            }
-          }
-        });
-      }
-    }
+    },
   ],
 } satisfies Config;


### PR DESCRIPTION
## Summary
- remove script injection from Tailwind config
- implement `useScrollFadeIn` hook to handle scroll animations on client
- update client components to use new hook

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b042217cdc83258d332c76de8b3cb6