### PR TITLE
feat: hide header actions until scrolled

### DIFF
--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -112,25 +112,30 @@ export default function Header({ transparent = false }) {
 
   return (
     <header className={headerClasses}>
-      <div className="flex items-center justify-between w-full px-4 py-4">
-        {/* Search */}
-        <Sheet>
-          <SheetTrigger asChild>
-            <button className={`${textClasses} p-2`}>
-              <Search className="h-5 w-5" />
-            </button>
-          </SheetTrigger>
-          <SheetContent side="top" className="h-[60vh] p-6">
-            <div className="flex items-center gap-2">
-              <Search className="h-5 w-5 text-muted-foreground" />
-              <input
-                type="text"
-                placeholder="Поиск по коже"
-                className="flex-1 bg-transparent border-b border-muted-foreground/20 pb-1 outline-none"
-              />
-            </div>
-          </SheetContent>
-        </Sheet>
+      <div
+        className={`flex w-full px-4 py-4 items-center ${
+          isScrolled ? "justify-between" : "justify-center"
+        }`}
+      >
+        {isScrolled && (
+          <Sheet>
+            <SheetTrigger asChild>
+              <button className={`${textClasses} p-2`}>
+                <Search className="h-5 w-5" />
+              </button>
+            </SheetTrigger>
+            <SheetContent side="top" className="h-[60vh] p-6">
+              <div className="flex items-center gap-2">
+                <Search className="h-5 w-5 text-muted-foreground" />
+                <input
+                  type="text"
+                  placeholder="Поиск по коже"
+                  className="flex-1 bg-transparent border-b border-muted-foreground/20 pb-1 outline-none"
+                />
+              </div>
+            </SheetContent>
+          </Sheet>
+        )}
 
         {/* Logo */}
         <Link
@@ -140,66 +145,68 @@ export default function Header({ transparent = false }) {
           GRANDTEX
         </Link>
 
-        <div className="flex items-center gap-3">
-          <ThemeToggle className={`hidden md:block ${textClasses}`} />
-          <Sheet open={isMenuOpen} onOpenChange={setIsMenuOpen}>
-            <SheetTrigger asChild>
-              <button className={`${textClasses} p-2`}>
-                <Plus className="h-6 w-6" />
-              </button>
-            </SheetTrigger>
-            <SheetContent
-              side="bottom"
-              className="h-[80vh] p-0 flex flex-col overflow-hidden"
-            >
-              <div className="flex gap-4 overflow-x-auto p-4 border-b">
-                {navLinks.map((link, index) => (
-                  <button
-                    key={link.title}
-                    onClick={() => setActiveIndex(index)}
-                    className={`whitespace-nowrap ${
-                      activeIndex === index
-                        ? "text-foreground font-medium"
-                        : "text-muted-foreground"
-                    }`}
-                  >
-                    {link.title}
-                  </button>
-                ))}
-              </div>
-
-              <div className="flex-1 overflow-y-auto p-6">
-                <div className="grid grid-cols-1 gap-4">
-                  {(navLinks[activeIndex].subLinks ?? [navLinks[activeIndex]]).map(
-                    (item) => (
-                      <Link
-                        key={item.title}
-                        href={item.href}
-                        className="relative h-32 rounded-xl overflow-hidden block"
-                        onClick={() => setIsMenuOpen(false)}
-                      >
-                        {(item.image || navLinks[activeIndex].image) && (
-                          <Image
-                            src={item.image ?? navLinks[activeIndex].image!}
-                            alt={item.title}
-                            fill
-                            style={{ objectFit: "cover" }}
-                          />
-                        )}
-                        <div className="absolute inset-0 bg-gradient-to-t from-black/70 to-black/10 p-4 flex flex-col justify-between">
-                          <span className="text-primary-foreground text-lg font-medium">
-                            {item.title}
-                          </span>
-                          <ArrowRight className="self-end h-5 w-5 text-primary-foreground" />
-                        </div>
-                      </Link>
-                    )
-                  )}
+        {isScrolled && (
+          <div className="flex items-center gap-3">
+            <ThemeToggle className={`hidden md:block ${textClasses}`} />
+            <Sheet open={isMenuOpen} onOpenChange={setIsMenuOpen}>
+              <SheetTrigger asChild>
+                <button className={`${textClasses} p-2`}>
+                  <Plus className="h-6 w-6" />
+                </button>
+              </SheetTrigger>
+              <SheetContent
+                side="bottom"
+                className="h-[80vh] p-0 flex flex-col overflow-hidden"
+              >
+                <div className="flex gap-4 overflow-x-auto p-4 border-b">
+                  {navLinks.map((link, index) => (
+                    <button
+                      key={link.title}
+                      onClick={() => setActiveIndex(index)}
+                      className={`whitespace-nowrap ${
+                        activeIndex === index
+                          ? "text-foreground font-medium"
+                          : "text-muted-foreground"
+                      }`}
+                    >
+                      {link.title}
+                    </button>
+                  ))}
                 </div>
-              </div>
-            </SheetContent>
-          </Sheet>
-        </div>
+
+                <div className="flex-1 overflow-y-auto p-6">
+                  <div className="grid grid-cols-1 gap-4">
+                    {(navLinks[activeIndex].subLinks ?? [navLinks[activeIndex]]).map(
+                      (item) => (
+                        <Link
+                          key={item.title}
+                          href={item.href}
+                          className="relative h-32 rounded-xl overflow-hidden block"
+                          onClick={() => setIsMenuOpen(false)}
+                        >
+                          {(item.image || navLinks[activeIndex].image) && (
+                            <Image
+                              src={item.image ?? navLinks[activeIndex].image!}
+                              alt={item.title}
+                              fill
+                              style={{ objectFit: "cover" }}
+                            />
+                          )}
+                          <div className="absolute inset-0 bg-gradient-to-t from-black/70 to-black/10 p-4 flex flex-col justify-between">
+                            <span className="text-primary-foreground text-lg font-medium">
+                              {item.title}
+                            </span>
+                            <ArrowRight className="self-end h-5 w-5 text-primary-foreground" />
+                          </div>
+                        </Link>
+                      )
+                    )}
+                  </div>
+                </div>
+              </SheetContent>
+            </Sheet>
+          </div>
+        )}
       </div>
     </header>
   );


### PR DESCRIPTION
## Summary
- render search and menu buttons only after header scroll
- show logo centered when not scrolled

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b0861a5a3c83258acd4cb86e2792fc