### PR TITLE
refactor header config

### DIFF
--- a/src/app/about-grandtex/page.tsx
+++ b/src/app/about-grandtex/page.tsx
@@ -4,7 +4,7 @@ import MainLayout from "@/components/layout/MainLayout";
 
 export default function AboutPage() {
   return (
-    <MainLayout>
+    <MainLayout transparentHeader={{ transparent: false }}>
       {/* Hero Section */}
       <section className="relative w-full h-[60vh] bg-primary text-primary-foreground mt-20">
         <div className="absolute inset-0 z-0">

--- a/src/app/collections/[id]/page.tsx
+++ b/src/app/collections/[id]/page.tsx
@@ -129,7 +129,7 @@ export default async function CollectionDetailPage({
 
   if (!collection) {
     return (
-      <MainLayout>
+      <MainLayout transparentHeader={{ transparent: false }}>
         <div className="py-40 px-8 text-center">
           <h1 className="text-3xl font-bold mb-4">Коллекция не найдена</h1>
           <p className="mb-8">
@@ -147,7 +147,7 @@ export default async function CollectionDetailPage({
   }
 
   return (
-    <MainLayout>
+    <MainLayout transparentHeader={{ transparent: false }}>
       <div className="mt-20">
         {/* Hero Section */}
         <section className="relative w-full h-[60vh] bg-primary text-primary-foreground">

--- a/src/app/collections/page.tsx
+++ b/src/app/collections/page.tsx
@@ -47,7 +47,7 @@ export default function CollectionsPage() {
   ];
 
   return (
-    <MainLayout>
+    <MainLayout transparentHeader={{ transparent: false }}>
       {/* Hero Section */}
       <section className="relative w-full h-[40vh] bg-primary text-primary-foreground mt-20">
         <div className="absolute inset-0 z-0">

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -4,7 +4,7 @@ import MainLayout from "@/components/layout/MainLayout";
 
 export default function ContactPage() {
   return (
-    <MainLayout>
+    <MainLayout transparentHeader={{ transparent: false }}>
       {/* Hero Section */}
       <section className="relative w-full h-[40vh] bg-primary text-primary-foreground mt-20">
         <div className="absolute inset-0 z-0">

--- a/src/app/leathers/[id]/page.tsx
+++ b/src/app/leathers/[id]/page.tsx
@@ -116,7 +116,7 @@ export default async function LeatherDetailPage({
 
   if (!product) {
     return (
-      <MainLayout>
+      <MainLayout transparentHeader={{ transparent: false }}>
         <div className="py-40 px-8 text-center">
           <h1 className="text-3xl font-bold mb-4">Продукт не найден</h1>
           <p className="mb-8">
@@ -134,7 +134,7 @@ export default async function LeatherDetailPage({
   }
 
   return (
-    <MainLayout>
+    <MainLayout transparentHeader={{ transparent: false }}>
       <div className="mt-20 pt-8">
         {/* Breadcrumb */}
         <div className="container mx-auto px-8 mb-8">

--- a/src/app/leathers/page.tsx
+++ b/src/app/leathers/page.tsx
@@ -62,7 +62,7 @@ export default function LeathersPage() {
   ];
 
   return (
-    <MainLayout>
+    <MainLayout transparentHeader={{ transparent: false }}>
       {/* Hero Section */}
       <section className="relative w-full h-[40vh] bg-primary text-primary-foreground mt-20">
         <div className="absolute inset-0 z-0">

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -91,7 +91,7 @@ export default function Home() {
   ];
 
   return (
-    <MainLayout transparentHeader={true}>
+    <MainLayout transparentHeader={{ transparent: true }}>
       <LetterLoader
         text="Grandtex Leather"
         className="mt-8 text-center text-4xl font-bold"

--- a/src/app/sustainability/page.tsx
+++ b/src/app/sustainability/page.tsx
@@ -4,7 +4,7 @@ import MainLayout from "@/components/layout/MainLayout";
 
 export default function SustainabilityPage() {
   return (
-    <MainLayout>
+    <MainLayout transparentHeader={{ transparent: false }}>
       {/* Hero Section */}
       <section className="relative w-full h-[60vh] bg-primary text-primary-foreground mt-20">
         <div className="absolute inset-0 z-0">

--- a/src/app/tanneries/page.tsx
+++ b/src/app/tanneries/page.tsx
@@ -49,7 +49,7 @@ export default function TanneriesPage() {
   ];
 
   return (
-    <MainLayout>
+    <MainLayout transparentHeader={{ transparent: false }}>
       {/* Hero Section */}
       <section className="relative w-full h-[50vh] bg-primary text-primary-foreground mt-20">
         <div className="absolute inset-0 z-0">

--- a/src/app/why-grandtex/page.tsx
+++ b/src/app/why-grandtex/page.tsx
@@ -43,7 +43,7 @@ export default function WhyGrandtexPage() {
   ];
 
   return (
-    <MainLayout>
+    <MainLayout transparentHeader={{ transparent: false }}>
       {/* Hero Section */}
       <section className="relative w-full h-[50vh] bg-primary text-primary-foreground mt-20">
         <div className="absolute inset-0 z-0">

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -7,7 +7,25 @@ import { Sheet, SheetContent, SheetTrigger } from "@/components/ui/sheet";
 import ThemeToggle from "@/components/ThemeToggle";
 import { Search, Plus, ArrowRight } from "lucide-react";
 
-export default function Header({ transparent = false }) {
+import { defaultNavLinks } from "./navLinks";
+
+export interface NavLink {
+  title: string;
+  href: string;
+  image?: string;
+  subLinks?: NavLink[];
+}
+
+export interface HeaderConfig {
+  transparent: boolean;
+  links?: NavLink[];
+}
+
+interface HeaderProps {
+  config: HeaderConfig;
+}
+export default function Header({ config }: HeaderProps) {
+  const { transparent, links } = config;
   const [isScrolled, setIsScrolled] = useState(false);
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const [activeIndex, setActiveIndex] = useState(0);
@@ -27,88 +45,7 @@ export default function Header({ transparent = false }) {
 
   const textClasses =
     transparent && !isScrolled ? "text-primary-foreground" : "text-foreground";
-
-  const navLinks: {
-    title: string;
-    href: string;
-    image?: string;
-    subLinks?: { title: string; href: string; image?: string }[];
-  }[] = [
-    {
-      title: "Кожа",
-      href: "/leathers",
-      image: "https://ext.same-assets.com/1118492138/3442149313.jpeg",
-      subLinks: [
-        {
-          title: "Коллекция Весна-Лето 27",
-          href: "/collections/spring-summer-2027",
-        },
-        {
-          title: "Коллекция Осень-Зима 26",
-          href: "/collections/fw26",
-        },
-      ],
-    },
-    {
-      title: "Тиснение и перфорация",
-      href: "/emboss-perforation",
-      image: "https://ext.same-assets.com/1118492138/3513175735.jpeg",
-    },
-    {
-      title: "Почему GRANDTEX?",
-      href: "/why-grandtex",
-      image: "https://ext.same-assets.com/1118492138/2560085916.jpeg",
-      subLinks: [
-        {
-          title: "О GRANDTEX",
-          href: "/about-grandtex",
-        },
-        {
-          title: "Кожевенные заводы",
-          href: "/tanneries",
-        },
-      ],
-    },
-    {
-      title: "Устойчивость",
-      href: "/sustainability",
-      image: "https://ext.same-assets.com/1118492138/180971912.jpeg",
-      subLinks: [
-        {
-          title: "Операционное совершенство",
-          href: "/sustainability#operational-excellence",
-        },
-        {
-          title: "Циркулярность",
-          href: "/sustainability#circularity",
-        },
-        {
-          title: "Климатические действия",
-          href: "/sustainability#climate-action",
-        },
-        {
-          title: "Социальное воздействие",
-          href: "/sustainability#social-impact",
-        },
-      ],
-    },
-    {
-      title: "Основные моменты",
-      href: "/highlights",
-    },
-    {
-      title: "Обучение",
-      href: "/education",
-    },
-    {
-      title: "Локации",
-      href: "/contact",
-    },
-    {
-      title: "Ресурсы",
-      href: "/resources",
-    },
-  ];
+  const navLinks = links ?? defaultNavLinks;
 
   return (
     <header className={headerClasses}>

--- a/src/components/layout/MainLayout.tsx
+++ b/src/components/layout/MainLayout.tsx
@@ -1,20 +1,20 @@
-import Header from './Header';
+import Header, { HeaderConfig } from './Header';
 import Footer from './Footer';
 import CookieConsent from './CookieConsent';
 import Animations from '@/app/animations';
 
 interface MainLayoutProps {
   children: React.ReactNode;
-  transparentHeader?: boolean;
+  transparentHeader?: HeaderConfig;
 }
 
 export default function MainLayout({
   children,
-  transparentHeader = false
+  transparentHeader = { transparent: false }
 }: MainLayoutProps) {
   return (
     <div className="min-h-screen flex flex-col">
-      <Header transparent={transparentHeader} />
+      <Header config={transparentHeader} />
       <main className="flex-1">
         {children}
       </main>

--- a/src/components/layout/navLinks.ts
+++ b/src/components/layout/navLinks.ts
@@ -1,0 +1,58 @@
+import type { NavLink } from "./Header";
+
+export const defaultNavLinks: NavLink[] = [
+  {
+    title: "Кожа",
+    href: "/leathers",
+    image: "https://ext.same-assets.com/1118492138/3442149313.jpeg",
+    subLinks: [
+      {
+        title: "Коллекция Весна-Лето 27",
+        href: "/collections/spring-summer-2027",
+      },
+      {
+        title: "Коллекция Осень-Зима 26",
+        href: "/collections/fw26",
+      },
+    ],
+  },
+  {
+    title: "Тиснение и перфорация",
+    href: "/emboss-perforation",
+    image: "https://ext.same-assets.com/1118492138/3513175735.jpeg",
+  },
+  {
+    title: "Почему GRANDTEX?",
+    href: "/why-grandtex",
+    image: "https://ext.same-assets.com/1118492138/2560085916.jpeg",
+    subLinks: [
+      { title: "О GRANDTEX", href: "/about-grandtex" },
+      { title: "Кожевенные заводы", href: "/tanneries" },
+    ],
+  },
+  {
+    title: "Устойчивость",
+    href: "/sustainability",
+    image: "https://ext.same-assets.com/1118492138/180971912.jpeg",
+    subLinks: [
+      {
+        title: "Операционное совершенство",
+        href: "/sustainability#operational-excellence",
+      },
+      { title: "Циркулярность", href: "/sustainability#circularity" },
+      {
+        title: "Климатические действия",
+        href: "/sustainability#climate-action",
+      },
+      {
+        title: "Социальное воздействие",
+        href: "/sustainability#social-impact",
+      },
+    ],
+  },
+  { title: "Основные моменты", href: "/highlights" },
+  { title: "Обучение", href: "/education" },
+  { title: "Локации", href: "/contact" },
+  { title: "Ресурсы", href: "/resources" },
+];
+


### PR DESCRIPTION
## Summary
- allow pages to pass header configuration including transparency and custom links
- update layout and header to use config
- add default nav links source

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b0862059e48325ac86e23e24b6aa29