### PR TITLE
feat: add bottom sheet mobile navigation

### DIFF
--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -28,7 +28,6 @@ export default function Header({ config }: HeaderProps) {
   const { transparent, links } = config;
   const [isScrolled, setIsScrolled] = useState(false);
   const [isMenuOpen, setIsMenuOpen] = useState(false);
-  const [activeIndex, setActiveIndex] = useState(0);
 
   useEffect(() => {
     const handleScroll = () => {
@@ -84,79 +83,50 @@ export default function Header({ config }: HeaderProps) {
 
           <div className="flex items-center gap-3">
             <ThemeToggle className={`hidden md:block ${textClasses}`} />
-            <button
-              className={`${textClasses} p-2 md:hidden`}
-              onClick={() => setIsMenuOpen(!isMenuOpen)}
-              aria-label="Toggle menu"
-            >
-              <Plus
-                className={`h-6 w-6 transition-transform ${
-                  isMenuOpen ? "rotate-45" : ""
-                }`}
-              />
-            </button>
+            <Sheet open={isMenuOpen} onOpenChange={setIsMenuOpen}>
+              <SheetTrigger asChild>
+                <button
+                  className={`${textClasses} p-2 md:hidden`}
+                  aria-label="Toggle menu"
+                >
+                  <Plus
+                    className={`h-6 w-6 transition-transform ${
+                      isMenuOpen ? "rotate-45" : ""
+                    }`}
+                  />
+                </button>
+              </SheetTrigger>
+              <SheetContent side="bottom" className="p-6">
+                <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                  {navLinks.map((item) => (
+                    <Link
+                      key={item.title}
+                      href={item.href}
+                      className="relative h-32 rounded-xl overflow-hidden block"
+                      onClick={() => setIsMenuOpen(false)}
+                    >
+                      {item.image && (
+                        <Image
+                          src={item.image}
+                          alt={item.title}
+                          fill
+                          style={{ objectFit: "cover" }}
+                        />
+                      )}
+                      <div className="absolute inset-0 bg-gradient-to-t from-black/70 to-black/10 p-4 flex flex-col justify-between">
+                        <span className="text-primary-foreground text-lg font-medium">
+                          {item.title}
+                        </span>
+                        <ArrowRight className="self-end h-5 w-5 text-primary-foreground" />
+                      </div>
+                    </Link>
+                  ))}
+                </div>
+              </SheetContent>
+            </Sheet>
           </div>
         </div>
       </header>
-      <div
-        className={`fixed inset-0 z-40 flex flex-col bg-background transform transition-transform duration-300 md:hidden ${
-          isMenuOpen ? "translate-y-0" : "translate-y-full"
-        }`}
-      >
-        <div className="flex justify-end p-4 border-b">
-          <button
-            onClick={() => setIsMenuOpen(false)}
-            className="p-2 text-foreground"
-            aria-label="Close menu"
-          >
-            <Plus className="h-6 w-6 rotate-45" />
-          </button>
-        </div>
-        <div className="flex gap-4 overflow-x-auto p-4 border-b">
-          {navLinks.map((link, index) => (
-            <button
-              key={link.title}
-              onClick={() => setActiveIndex(index)}
-              className={`whitespace-nowrap ${
-                activeIndex === index
-                  ? "text-foreground font-medium"
-                  : "text-muted-foreground"
-              }`}
-            >
-              {link.title}
-            </button>
-          ))}
-        </div>
-        <div className="flex-1 overflow-y-auto p-6">
-          <div className="grid grid-cols-1 gap-4">
-            {(navLinks[activeIndex].subLinks ?? [navLinks[activeIndex]]).map(
-              (item) => (
-                <Link
-                  key={item.title}
-                  href={item.href}
-                  className="relative h-32 rounded-xl overflow-hidden block"
-                  onClick={() => setIsMenuOpen(false)}
-                >
-                  {(item.image || navLinks[activeIndex].image) && (
-                    <Image
-                      src={item.image ?? navLinks[activeIndex].image!}
-                      alt={item.title}
-                      fill
-                      style={{ objectFit: "cover" }}
-                    />
-                  )}
-                  <div className="absolute inset-0 bg-gradient-to-t from-black/70 to-black/10 p-4 flex flex-col justify-between">
-                    <span className="text-primary-foreground text-lg font-medium">
-                      {item.title}
-                    </span>
-                    <ArrowRight className="self-end h-5 w-5 text-primary-foreground" />
-                  </div>
-                </Link>
-              ),
-            )}
-          </div>
-        </div>
-      </div>
     </>
   );
 }

--- a/src/components/ui/sheet.tsx
+++ b/src/components/ui/sheet.tsx
@@ -1,19 +1,19 @@
-"use client"
+"use client";
 
-import * as React from "react"
-import * as SheetPrimitive from "@radix-ui/react-dialog"
-import { cva, type VariantProps } from "class-variance-authority"
-import { X } from "lucide-react"
+import * as React from "react";
+import * as SheetPrimitive from "@radix-ui/react-dialog";
+import { cva, type VariantProps } from "class-variance-authority";
+import { X } from "lucide-react";
 
-import { cn } from "@/lib/utils"
+import { cn } from "@/lib/utils";
 
-const Sheet = SheetPrimitive.Root
+const Sheet = SheetPrimitive.Root;
 
-const SheetTrigger = SheetPrimitive.Trigger
+const SheetTrigger = SheetPrimitive.Trigger;
 
-const SheetClose = SheetPrimitive.Close
+const SheetClose = SheetPrimitive.Close;
 
-const SheetPortal = SheetPrimitive.Portal
+const SheetPortal = SheetPrimitive.Portal;
 
 const SheetOverlay = React.forwardRef<
   React.ElementRef<typeof SheetPrimitive.Overlay>,
@@ -22,13 +22,13 @@ const SheetOverlay = React.forwardRef<
   <SheetPrimitive.Overlay
     className={cn(
       "fixed inset-0 z-50 bg-primary/80 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
-      className
+      className,
     )}
     {...props}
     ref={ref}
   />
-))
-SheetOverlay.displayName = SheetPrimitive.Overlay.displayName
+));
+SheetOverlay.displayName = SheetPrimitive.Overlay.displayName;
 
 const sheetVariants = cva(
   "fixed z-50 gap-4 bg-background p-6 shadow-lg transition ease-in-out data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:duration-300 data-[state=open]:duration-500",
@@ -37,7 +37,7 @@ const sheetVariants = cva(
       side: {
         top: "inset-x-0 top-0 border-b data-[state=closed]:slide-out-to-top data-[state=open]:slide-in-from-top",
         bottom:
-          "inset-x-0 bottom-0 border-t data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom",
+          "inset-x-0 bottom-0 border-t rounded-t-3xl max-w-screen-md mx-auto data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom",
         left: "inset-y-0 left-0 h-full w-3/4 border-r data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left sm:max-w-sm",
         right:
           "inset-y-0 right-0 h-full w-3/4 border-l data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right sm:max-w-sm",
@@ -46,8 +46,8 @@ const sheetVariants = cva(
     defaultVariants: {
       side: "right",
     },
-  }
-)
+  },
+);
 
 interface SheetContentProps
   extends React.ComponentPropsWithoutRef<typeof SheetPrimitive.Content>,
@@ -71,8 +71,8 @@ const SheetContent = React.forwardRef<
       </SheetPrimitive.Close>
     </SheetPrimitive.Content>
   </SheetPortal>
-))
-SheetContent.displayName = SheetPrimitive.Content.displayName
+));
+SheetContent.displayName = SheetPrimitive.Content.displayName;
 
 const SheetHeader = ({
   className,
@@ -81,12 +81,12 @@ const SheetHeader = ({
   <div
     className={cn(
       "flex flex-col space-y-2 text-center sm:text-left",
-      className
+      className,
     )}
     {...props}
   />
-)
-SheetHeader.displayName = "SheetHeader"
+);
+SheetHeader.displayName = "SheetHeader";
 
 const SheetFooter = ({
   className,
@@ -95,12 +95,12 @@ const SheetFooter = ({
   <div
     className={cn(
       "flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2",
-      className
+      className,
     )}
     {...props}
   />
-)
-SheetFooter.displayName = "SheetFooter"
+);
+SheetFooter.displayName = "SheetFooter";
 
 const SheetTitle = React.forwardRef<
   React.ElementRef<typeof SheetPrimitive.Title>,
@@ -111,8 +111,8 @@ const SheetTitle = React.forwardRef<
     className={cn("text-lg font-semibold text-foreground", className)}
     {...props}
   />
-))
-SheetTitle.displayName = SheetPrimitive.Title.displayName
+));
+SheetTitle.displayName = SheetPrimitive.Title.displayName;
 
 const SheetDescription = React.forwardRef<
   React.ElementRef<typeof SheetPrimitive.Description>,
@@ -123,8 +123,8 @@ const SheetDescription = React.forwardRef<
     className={cn("text-sm text-muted-foreground", className)}
     {...props}
   />
-))
-SheetDescription.displayName = SheetPrimitive.Description.displayName
+));
+SheetDescription.displayName = SheetPrimitive.Description.displayName;
 
 export {
   Sheet,
@@ -137,4 +137,4 @@ export {
   SheetFooter,
   SheetTitle,
   SheetDescription,
-}
+};


### PR DESCRIPTION
## Summary
- expand bottom sheet variant with rounded top and centered width
- use bottom-sheet navigation in header with animated open/close
- render nav links as responsive grid cards

## Testing
- `bun run lint`

------
https://chatgpt.com/codex/tasks/task_e_68b090fd2b2c8325b8404651e02e4568