### PR TITLE
fix: remove invalid page export

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -24,6 +24,7 @@
         "@types/node": "^20.17.50",
         "@types/react": "^18.3.22",
         "@types/react-dom": "^18.3.7",
+        "@types/winston": "^2.4.4",
         "eslint": "^9.27.0",
         "eslint-config-next": "15.1.7",
         "husky": "^9.1.7",
@@ -229,6 +230,8 @@
     "@types/react-reconciler": ["@types/react-reconciler@0.28.9", "", { "peerDependencies": { "@types/react": "*" } }, "sha512-HHM3nxyUZ3zAylX8ZEyrDNd2XZOnQ0D5XfunJF5FLQnZbHHYq4UWvW1QfelQNXv1ICNkwYhfxjwfnqivYB6bFg=="],
 
     "@types/triple-beam": ["@types/triple-beam@1.3.5", "", {}, "sha512-6WaYesThRMCl19iryMYP7/x2OVgCtbIVflDGFpWnb9irXI3UjYE4AzmYuiUKY1AJstGijoY+MgUszMgRxIYTYw=="],
+
+    "@types/winston": ["@types/winston@2.4.4", "", { "dependencies": { "winston": "*" } }, "sha512-BVGCztsypW8EYwJ+Hq+QNYiT/MUyCif0ouBH+flrY66O5W+KIXAMML6E/0fJpm7VjIzgangahl5S03bJJQGrZw=="],
 
     "@typescript-eslint/eslint-plugin": ["@typescript-eslint/eslint-plugin@8.25.0", "", { "dependencies": { "@eslint-community/regexpp": "^4.10.0", "@typescript-eslint/scope-manager": "8.25.0", "@typescript-eslint/type-utils": "8.25.0", "@typescript-eslint/utils": "8.25.0", "@typescript-eslint/visitor-keys": "8.25.0", "graphemer": "^1.4.0", "ignore": "^5.3.1", "natural-compare": "^1.4.0", "ts-api-utils": "^2.0.1" }, "peerDependencies": { "@typescript-eslint/parser": "^8.0.0 || ^8.0.0-alpha.0", "eslint": "^8.57.0 || ^9.0.0", "typescript": ">=4.8.4 <5.8.0" } }, "sha512-VM7bpzAe7JO/BFf40pIT1lJqS/z1F8OaSsUB3rpFJucQA4cOSuH2RVVVkFULN+En0Djgr29/jb4EQnedUo95KA=="],
 

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "@types/node": "^20.17.50",
     "@types/react": "^18.3.22",
     "@types/react-dom": "^18.3.7",
+    "@types/winston": "^2.4.4",
     "eslint": "^9.27.0",
     "eslint-config-next": "15.1.7",
     "husky": "^9.1.7",

--- a/src/app/admin/audit/AuditTable.tsx
+++ b/src/app/admin/audit/AuditTable.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useMemo, useState } from "react";
-import type { AuditEntry } from "./page";
+import type { AuditEntry } from "./actions";
 
 interface Props {
   initialEntries: AuditEntry[];

--- a/src/app/admin/audit/actions.ts
+++ b/src/app/admin/audit/actions.ts
@@ -1,0 +1,20 @@
+export type AuditEntry = {
+  id: number;
+  user: string;
+  action: string;
+  date: string; // ISO string
+};
+
+export async function getAuditEntries(): Promise<AuditEntry[]> {
+  "use server";
+  return [
+    { id: 1, user: "alice", action: "login", date: "2024-01-01T12:00:00Z" },
+    { id: 2, user: "bob", action: "logout", date: "2024-01-02T08:30:00Z" },
+    {
+      id: 3,
+      user: "alice",
+      action: "update profile",
+      date: "2024-01-03T10:15:00Z",
+    },
+  ];
+}

--- a/src/app/admin/audit/page.tsx
+++ b/src/app/admin/audit/page.tsx
@@ -1,27 +1,7 @@
 import AuditTable from "./AuditTable";
 import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
-
-export type AuditEntry = {
-  id: number;
-  user: string;
-  action: string;
-  date: string; // ISO string
-};
-
-export async function getAuditEntries(): Promise<AuditEntry[]> {
-  "use server";
-  return [
-    { id: 1, user: "alice", action: "login", date: "2024-01-01T12:00:00Z" },
-    { id: 2, user: "bob", action: "logout", date: "2024-01-02T08:30:00Z" },
-    {
-      id: 3,
-      user: "alice",
-      action: "update profile",
-      date: "2024-01-03T10:15:00Z",
-    },
-  ];
-}
+import { getAuditEntries } from "./actions";
 
 export default async function AuditPage() {
   const cookieStore = await cookies();


### PR DESCRIPTION
## Summary
- move audit entry type and fetching to an actions module
- update audit page and table to use dedicated actions file
- add `@types/winston` for type checking

## Testing
- `bun run lint`
- `bun run build`


------
https://chatgpt.com/codex/tasks/task_e_68b094151228832588c58f085b68b14d