### PR TITLE
Add animated home page sections

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,12 +1,17 @@
 import HeroPrime from "@/components/HeroPrime";
 import LeatherCard from "@/components/LeatherCard";
+import AnimatedSection from "@/components/AnimatedSection";
+import SustainabilityPillars from "@/components/SustainabilityPillars";
+import LogoMarquee from "@/components/LogoMarquee";
+import Highlights from "@/components/Highlights";
+import CTA from "@/components/CTA";
 
 export default function Home() {
   return (
     <>
       <HeroPrime />
-      {/* Leathers preview */}
-      <section className="bg-background">
+
+      <AnimatedSection className="bg-background">
         <div className="container py-20">
           <h2 className="text-3xl md:text-4xl font-semibold">Leathers</h2>
           <p className="mt-3 text-muted-foreground max-w-2xl">
@@ -39,43 +44,13 @@ export default function Home() {
             />
           </div>
         </div>
-      </section>
+      </AnimatedSection>
 
-      {/* Sustainability */}
-      <section className="bg-secondary">
-        <div className="container py-20">
-          <h2 className="text-3xl md:text-4xl font-semibold">Sustainability</h2>
-          <p className="mt-3 text-muted-foreground max-w-2xl">
-            Consciously Crafted strategy across four pillars: Operational Excellence, Circularity, Climate Action, Social Impact.
-          </p>
-          {/* TODO: 4 колонки с пиларами */}
-        </div>
-      </section>
-
-      {/* Brands */}
-      <section>
-        <div className="container py-16">
-          <h3 className="text-xl text-muted-foreground">Trusted by</h3>
-          {/* TODO: лого-маркиза Adidas, Nike, Puma, etc. */}
-        </div>
-      </section>
-
-      {/* Highlights */}
-      <section className="bg-secondary">
-        <div className="container py-16">
-          <h2 className="text-3xl md:text-4xl font-semibold">Highlights</h2>
-          {/* TODO: 3 карточки с последними постами/новостями */}
-        </div>
-      </section>
-
-      {/* CTA */}
-      <section>
-        <div className="container py-20 text-center">
-          <a href="/contact" className="inline-flex px-6 py-4 rounded-md bg-primary text-primary-foreground hover:opacity-90 transition">
-            Contact us
-          </a>
-        </div>
-      </section>
+      <SustainabilityPillars />
+      <LogoMarquee />
+      <Highlights />
+      <CTA />
     </>
   );
 }
+

--- a/src/components/Highlights.tsx
+++ b/src/components/Highlights.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import Image from "next/image";
+import Link from "next/link";
+import { motion } from "framer-motion";
+
+interface Highlight {
+  title: string;
+  excerpt: string;
+  image: string;
+  href: string;
+}
+
+/**
+ * Displays recent news or blog posts with hover and scroll animations.
+ */
+export default function Highlights() {
+  const highlights: Highlight[] = [
+    {
+      title: "New EcoSoft line launched",
+      excerpt: "Our softest casual leather now comes with 40% less water usage.",
+      image: "https://picsum.photos/seed/highlight1/800/600",
+      href: "/highlights/ecosoft",
+    },
+    {
+      title: "PrimeFlex wins innovation award",
+      excerpt: "Recognised for durability and performance in athletic footwear.",
+      image: "https://picsum.photos/seed/highlight2/800/600",
+      href: "/highlights/primeflex-award",
+    },
+    {
+      title: "Tanneries reach carbon milestone",
+      excerpt: "Our facilities now run on 80% renewable energy worldwide.",
+      image: "https://picsum.photos/seed/highlight3/800/600",
+      href: "/highlights/carbon-milestone",
+    },
+  ];
+
+  return (
+    <section className="bg-secondary">
+      <div className="container py-16">
+        <h2 className="text-3xl md:text-4xl font-semibold">Highlights</h2>
+        <div className="mt-8 grid gap-8 md:grid-cols-3">
+          {highlights.map((item, i) => (
+            <motion.article
+              key={item.title}
+              initial={{ opacity: 0, y: 20 }}
+              whileInView={{ opacity: 1, y: 0 }}
+              viewport={{ once: true }}
+              transition={{ delay: i * 0.1 }}
+              className="bg-background rounded-xl overflow-hidden shadow-sm"
+            >
+              <Image
+                src={item.image}
+                alt={item.title}
+                width={800}
+                height={600}
+                className="h-48 w-full object-cover transition-transform duration-500 hover:scale-105"
+              />
+              <div className="p-6">
+                <h3 className="text-lg font-semibold">{item.title}</h3>
+                <p className="mt-2 text-sm text-muted-foreground">{item.excerpt}</p>
+                <Link href={item.href} className="mt-4 inline-block text-primary hover:underline">
+                  Read more
+                </Link>
+              </div>
+            </motion.article>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}
+

--- a/src/components/LogoMarquee.tsx
+++ b/src/components/LogoMarquee.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import Image from "next/image";
+
+/**
+ * Horizontal marquee of brand logos. The animation is powered by custom
+ * Tailwind keyframes (see tailwind.config.ts).
+ */
+export default function LogoMarquee() {
+  const logos = [
+    "https://source.unsplash.com/random/160x80?adidas",
+    "https://source.unsplash.com/random/160x80?nike",
+    "https://source.unsplash.com/random/160x80?puma",
+    "https://source.unsplash.com/random/160x80?reebok",
+    "https://source.unsplash.com/random/160x80?newbalance",
+    "https://source.unsplash.com/random/160x80?asics",
+  ];
+
+  return (
+    <section className="py-16">
+      <div className="container">
+        <h3 className="text-xl text-muted-foreground text-center mb-10">Trusted by</h3>
+        <div className="relative overflow-hidden">
+          <div className="flex gap-16 animate-marquee">
+            {logos.concat(logos).map((logo, idx) => (
+              <Image
+                key={idx}
+                src={logo}
+                alt="brand logo"
+                width={160}
+                height={80}
+                className="h-12 w-auto object-contain"
+              />
+            ))}
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}
+

--- a/src/components/SustainabilityPillars.tsx
+++ b/src/components/SustainabilityPillars.tsx
@@ -1,0 +1,85 @@
+"use client";
+
+import { Factory, Recycle, Sun, Users } from "lucide-react";
+import { motion } from "framer-motion";
+
+interface Pillar {
+  title: string;
+  description: string;
+  icon: React.ReactElement;
+}
+
+/**
+ * Displays the four pillars of the "Consciously Crafted" strategy with
+ * subtle animations when the cards enter the viewport.
+ */
+export default function SustainabilityPillars() {
+  const pillars: Pillar[] = [
+    {
+      title: "Operational Excellence",
+      description:
+        "Efficient resource use, waste reduction and pollution prevention across our tanneries.",
+      icon: <Factory className="h-8 w-8 text-primary" />,
+    },
+    {
+      title: "Circularity",
+      description:
+        "Designing products with a full life-cycle approach and finding new uses for by-products.",
+      icon: <Recycle className="h-8 w-8 text-primary" />,
+    },
+    {
+      title: "Climate Action",
+      description:
+        "Investing in renewable energy and striving for carbon neutrality by 2030.",
+      icon: <Sun className="h-8 w-8 text-primary" />,
+    },
+    {
+      title: "Social Impact",
+      description:
+        "Fair labour practices and community initiatives in every region where we operate.",
+      icon: <Users className="h-8 w-8 text-primary" />,
+    },
+  ];
+
+  return (
+    <section className="bg-secondary">
+      <div className="container py-20">
+        <motion.h2
+          initial={{ opacity: 0, y: 24 }}
+          whileInView={{ opacity: 1, y: 0 }}
+          viewport={{ once: true }}
+          transition={{ duration: 0.6 }}
+          className="text-3xl md:text-4xl font-semibold"
+        >
+          Sustainability
+        </motion.h2>
+        <motion.p
+          initial={{ opacity: 0, y: 24 }}
+          whileInView={{ opacity: 1, y: 0 }}
+          viewport={{ once: true }}
+          transition={{ duration: 0.6, delay: 0.1 }}
+          className="mt-3 text-muted-foreground max-w-2xl"
+        >
+          Consciously Crafted strategy across four pillars: Operational Excellence, Circularity, Climate Action and Social Impact.
+        </motion.p>
+        <div className="mt-10 grid gap-6 sm:grid-cols-2 lg:grid-cols-4">
+          {pillars.map((pillar, i) => (
+            <motion.div
+              key={pillar.title}
+              initial={{ opacity: 0, y: 20 }}
+              whileInView={{ opacity: 1, y: 0 }}
+              viewport={{ once: true }}
+              transition={{ delay: i * 0.1 }}
+              className="p-6 bg-background rounded-xl shadow-sm"
+            >
+              <div className="mb-4">{pillar.icon}</div>
+              <h3 className="text-lg font-semibold">{pillar.title}</h3>
+              <p className="mt-2 text-sm text-muted-foreground">{pillar.description}</p>
+            </motion.div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}
+

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -51,10 +51,15 @@ const config: Config = {
           '0%': { opacity: '0', transform: 'translateY(20px)' },
           '100%': { opacity: '1', transform: 'translateY(0)' },
         },
+        marquee: {
+          '0%': { transform: 'translateX(0)' },
+          '100%': { transform: 'translateX(-50%)' },
+        },
       },
       animation: {
         'fade-in': 'fade-in 1s ease forwards',
         'fade-up': 'fade-up 0.6s ease forwards',
+        marquee: 'marquee 20s linear infinite',
       },
       borderRadius: {
         lg: 'var(--radius)',
@@ -76,3 +81,4 @@ const config: Config = {
 };
 
 export default config;
+


### PR DESCRIPTION
## Summary
- add sustainability pillars component with framer-motion animations
- introduce logo marquee and highlights sections on home page
- extend Tailwind config with marquee keyframes and animation

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b0b555e33c8325ba25eef78a0ea72e