### PR TITLE
fix: ensure autoprefixer dependency

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,6 +5,7 @@
       "name": "nextjs-shadcn",
       "dependencies": {
         "@radix-ui/react-dialog": "^1.1.15",
+        "autoprefixer": "^10.4.21",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "framer-motion": "^12.23.12",
@@ -21,7 +22,6 @@
         "@types/react": "^18.3.22",
         "@types/react-dom": "^18.3.7",
         "@types/winston": "^2.4.4",
-        "autoprefixer": "^10.4.14",
         "eslint": "^9.34.0",
         "eslint-config-next": "^15.5.2",
         "postcss": "^8.5.3",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "next": "^15.3.2",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
+    "autoprefixer": "^10.4.21",
     "tailwind-merge": "^3.3.0",
     "tailwindcss": "^3.4.17",
     "winston": "^3.17.0"
@@ -27,7 +28,6 @@
     "@types/react": "^18.3.22",
     "@types/react-dom": "^18.3.7",
     "@types/winston": "^2.4.4",
-    "autoprefixer": "^10.4.14",
     "eslint": "^9.34.0",
     "eslint-config-next": "^15.5.2",
     "postcss": "^8.5.3",


### PR DESCRIPTION
## Summary
- move autoprefixer from devDependencies to dependencies so builds succeed
- update lockfile for new dependency layout

## Testing
- `npm run lint`
- `npx tsc --noEmit`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b0fb6d3a388325afeb89d556571e57