### PR TITLE
feat: improve audit table responsiveness

### DIFF
--- a/src/app/admin/audit/AuditTable.tsx
+++ b/src/app/admin/audit/AuditTable.tsx
@@ -62,40 +62,60 @@ export default function AuditTable({ initialEntries }: Props) {
     <div className="space-y-4">
       <div className="flex flex-wrap gap-2">
         <input
-          className="border px-2 py-1"
+          className="border px-4 h-11 w-full sm:w-auto flex-1"
           placeholder="User"
           value={user}
           onChange={(e) => setUser(e.target.value)}
         />
         <input
-          className="border px-2 py-1"
+          className="border px-4 h-11 w-full sm:w-auto flex-1"
           placeholder="Action"
           value={action}
           onChange={(e) => setAction(e.target.value)}
         />
         <input
-          className="border px-2 py-1"
+          className="border px-4 h-11 w-full sm:w-auto"
           type="date"
           value={date}
           onChange={(e) => setDate(e.target.value)}
         />
-        <button className="border px-2 py-1" onClick={exportCsv}>
+        <button
+          className="border px-4 h-11 w-full sm:w-auto"
+          onClick={exportCsv}
+        >
           Export CSV
         </button>
       </div>
-      <table className="min-w-full text-left border">
+      <div className="space-y-2 md:hidden">
+        {entries.map((e) => (
+          <div key={e.id} className="border rounded p-4">
+            <div className="font-medium">{e.user}</div>
+            <div className="text-sm">{e.action}</div>
+            <div className="text-xs text-gray-600">
+              {new Date(e.date).toLocaleString()}
+            </div>
+          </div>
+        ))}
+      </div>
+      <table className="hidden md:table w-full text-left border">
         <thead>
           <tr>
-            <th className="cursor-pointer px-2" onClick={() => onSort("user")}>
+            <th
+              className="cursor-pointer px-2 h-11"
+              onClick={() => onSort("user")}
+            >
               User
             </th>
             <th
-              className="cursor-pointer px-2"
+              className="cursor-pointer px-2 h-11"
               onClick={() => onSort("action")}
             >
               Action
             </th>
-            <th className="cursor-pointer px-2" onClick={() => onSort("date")}>
+            <th
+              className="cursor-pointer px-2 h-11"
+              onClick={() => onSort("date")}
+            >
               Date
             </th>
           </tr>
@@ -103,9 +123,9 @@ export default function AuditTable({ initialEntries }: Props) {
         <tbody>
           {entries.map((e) => (
             <tr key={e.id} className="border-t">
-              <td className="px-2 py-1">{e.user}</td>
-              <td className="px-2 py-1">{e.action}</td>
-              <td className="px-2 py-1">{new Date(e.date).toLocaleString()}</td>
+              <td className="px-2 py-3">{e.user}</td>
+              <td className="px-2 py-3">{e.action}</td>
+              <td className="px-2 py-3">{new Date(e.date).toLocaleString()}</td>
             </tr>
           ))}
         </tbody>


### PR DESCRIPTION
## Summary
- add responsive breakpoints and larger touch targets to audit filters
- show audit entries as stacked cards on small screens while keeping table for md+

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b08582a0548325aa2a5118330fb962