### PR TITLE
Rebrand hero and product sections for apparel manufacturing

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,5 @@
 import HeroPrime from "@/components/HeroPrime";
-import LeatherCard from "@/components/LeatherCard";
+import ProductCard from "@/components/ProductCard";
 import AnimatedSection from "@/components/AnimatedSection";
 import SustainabilityPillars from "@/components/SustainabilityPillars";
 import LogoMarquee from "@/components/LogoMarquee";
@@ -13,34 +13,34 @@ export default function Home() {
 
       <AnimatedSection className="bg-background">
         <div className="container py-20">
-          <h2 className="text-3xl md:text-4xl font-semibold">Leathers</h2>
+          <h2 className="text-3xl md:text-4xl font-semibold">Collections</h2>
           <p className="mt-3 text-muted-foreground max-w-2xl">
-            A wide range of athletic and casual leathers, crafted for performance, style and consistency.
+            A curated selection of apparel staples, built for comfort, durability, and style.
           </p>
           <div className="mt-8 grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
-            <LeatherCard
-              title="PrimeFlex"
-              collection="Athletic"
-              type="Calf"
-              finish="Matte"
-              href="/leathers/primeflex"
-              image="https://picsum.photos/seed/primeflex/1200/800"
-            />
-            <LeatherCard
-              title="EcoSoft"
+            <ProductCard
+              title="Classic Tee"
               collection="Casual"
-              type="Cow"
-              finish="Soft"
-              href="/leathers/ecosoft"
-              image="https://picsum.photos/seed/ecosoft/1200/800"
+              type="Cotton"
+              finish="Regular fit"
+              href="/collections/classic-tee"
+              image="https://picsum.photos/seed/classictee/1200/800"
             />
-            <LeatherCard
-              title="TrailGuard"
+            <ProductCard
+              title="Denim Jacket"
+              collection="Denim"
+              type="Denim"
+              finish="Slim fit"
+              href="/collections/denim-jacket"
+              image="https://picsum.photos/seed/denimjacket/1200/800"
+            />
+            <ProductCard
+              title="Trail Hoodie"
               collection="Outdoor"
-              type="Buffalo"
-              finish="Oiled"
-              href="/leathers/trailguard"
-              image="https://picsum.photos/seed/trailguard/1200/800"
+              type="Fleece"
+              finish="Relaxed fit"
+              href="/collections/trail-hoodie"
+              image="https://picsum.photos/seed/trailhoodie/1200/800"
             />
           </div>
         </div>

--- a/src/components/HeroPrime.tsx
+++ b/src/components/HeroPrime.tsx
@@ -9,7 +9,7 @@ export default function HeroPrime() {
       {/* video background (можно заменить на свой .mp4) */}
       <video
         className="absolute inset-0 h-full w-full object-cover"
-        src="https://videos.pexels.com/video-files/856966/856966-uhd_2560_1440_25fps.mp4"
+        src="https://videos.pexels.com/video-files/3772666/3772666-hd_1920_1080_25fps.mp4"
         autoPlay
         muted
         loop
@@ -23,7 +23,7 @@ export default function HeroPrime() {
           transition={{ duration: 0.8, ease: "easeOut" }}
           className="text-4xl md:text-6xl font-semibold leading-tight tracking-tight"
         >
-          Accelerate Ahead.
+          Stitching Your Vision.
         </motion.h1>
         <motion.p
           initial={{ opacity: 0, y: 24 }}
@@ -31,7 +31,7 @@ export default function HeroPrime() {
           transition={{ duration: 0.9, ease: "easeOut", delay: 0.1 }}
           className="mt-4 max-w-xl text-lg md:text-xl text-muted-foreground"
         >
-          Future-forward tannery expertise for brands of every size.
+          Full-service garment manufacturing for brands and designers.
         </motion.p>
         <motion.div
           initial={{ opacity: 0, y: 24 }}
@@ -39,11 +39,11 @@ export default function HeroPrime() {
           transition={{ duration: 0.9, ease: "easeOut", delay: 0.2 }}
           className="mt-8 flex gap-4"
         >
-          <Link href="/leathers" className="px-5 py-3 rounded-md bg-primary text-primary-foreground hover:opacity-90 transition">
-            Explore Leathers
+          <Link href="/services" className="px-5 py-3 rounded-md bg-primary text-primary-foreground hover:opacity-90 transition">
+            Our Services
           </Link>
-          <Link href="/sustainability" className="px-5 py-3 rounded-md bg-secondary text-secondary-foreground hover:bg-secondary/80 transition">
-            Sustainability
+          <Link href="/contact" className="px-5 py-3 rounded-md bg-secondary text-secondary-foreground hover:bg-secondary/80 transition">
+            Request a Quote
           </Link>
         </motion.div>
       </div>

--- a/src/components/ProductCard.tsx
+++ b/src/components/ProductCard.tsx
@@ -1,6 +1,6 @@
 import Image from "next/image";
 
-export default function LeatherCard({
+export default function ProductCard({
   title,
   collection,
   type,


### PR DESCRIPTION
## Summary
- Replace hero background video and messaging to highlight garment production services
- Rename LeatherCard to ProductCard and update home page to showcase clothing collections

## Testing
- `npm run lint` *(fails: Cannot read properties of undefined (reading 'endsWith'))*
- `npx eslint .`

------
https://chatgpt.com/codex/tasks/task_e_68b0fc606a648325a4cff473e550f67c