### PR TITLE
Add cleanup for product hover effects

### DIFF
--- a/src/app/animations.tsx
+++ b/src/app/animations.tsx
@@ -12,11 +12,12 @@ export default function Animations() {
     const cleanupParallax = initParallaxEffect();
 
     // Initialize product hover effects
-    initProductHoverEffects();
+    const cleanupProductHover = initProductHoverEffects();
 
     // Cleanup on unmount
     return () => {
       if (cleanupParallax) cleanupParallax();
+      if (cleanupProductHover) cleanupProductHover();
     };
   }, []);
 

--- a/src/lib/animate.ts
+++ b/src/lib/animate.ts
@@ -76,23 +76,41 @@ export const initProductHoverEffects = () => {
     return;
   }
 
+  const handlers: {
+    card: Element;
+    enter: () => void;
+    leave: () => void;
+  }[] = [];
+
   productCards.forEach((card) => {
-    card.addEventListener("mouseenter", () => {
+    const handleMouseEnter = () => {
       card.classList.add("scale-[1.02]");
 
       const image = card.querySelector("[data-product-image]");
       if (image) {
         image.classList.add("scale-110");
       }
-    });
+    };
 
-    card.addEventListener("mouseleave", () => {
+    const handleMouseLeave = () => {
       card.classList.remove("scale-[1.02]");
 
       const image = card.querySelector("[data-product-image]");
       if (image) {
         image.classList.remove("scale-110");
       }
-    });
+    };
+
+    card.addEventListener("mouseenter", handleMouseEnter);
+    card.addEventListener("mouseleave", handleMouseLeave);
+
+    handlers.push({ card, enter: handleMouseEnter, leave: handleMouseLeave });
   });
+
+  return () => {
+    handlers.forEach(({ card, enter, leave }) => {
+      card.removeEventListener("mouseenter", enter);
+      card.removeEventListener("mouseleave", leave);
+    });
+  };
 };


### PR DESCRIPTION
## Summary
- save handler references for product hover animations and expose cleanup
- call product hover cleanup in animations init hook

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b10923db088325b66debc8d4c7f803