### PR TITLE
Enable image accessibility lint rules

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -21,8 +21,6 @@ const eslintConfig = [
     rules: {
       "@typescript-eslint/no-unused-vars": "off",
       "react/no-unescaped-entities": "off",
-      "@next/next/no-img-element": "off",
-      "jsx-a11y/alt-text": "off",
     },
   },
 ];


### PR DESCRIPTION
## Summary
- remove explicit disabling of `@next/next/no-img-element` and `jsx-a11y/alt-text`

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b109366ad08325b4a43013b3e9aa4c