### PR TITLE
Use logger in middleware

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,14 +1,13 @@
 import { NextRequest, NextResponse } from "next/server";
+import logger from "./lib/logger";
 
 export function middleware(request: NextRequest) {
   const userId = request.headers.get("x-user-id") || "anonymous";
 
-  console.info({
-    message: "API request",
+  logger.info("API request", {
     method: request.method,
     url: request.url,
     userId,
-    timestamp: new Date().toISOString(),
   });
 
   return NextResponse.next();


### PR DESCRIPTION
## Summary
- use shared Winston logger in API middleware
- record API request metadata via logger instead of console

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b1093c5c448325a8edb482c61cce4c