### PR TITLE
feat: add static client logos

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -2,22 +2,6 @@
 const nextConfig = {
   images: {
     unoptimized: true,
-    domains: [
-      'images.unsplash.com',
-      'source.unsplash.com',
-    ],
-    remotePatterns: [
-      {
-        protocol: 'https',
-        hostname: 'source.unsplash.com',
-        pathname: '/**'
-      },
-      {
-        protocol: 'https',
-        hostname: 'images.unsplash.com',
-        pathname: '/**'
-      }
-    ]
   },
 };
 

--- a/public/clients/activewear-pro.svg
+++ b/public/clients/activewear-pro.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="200" height="100" viewBox="0 0 200 100">
+  <rect width="200" height="100" fill="#e5e7eb"/>
+  <text x="100" y="55" text-anchor="middle" font-size="40" fill="#374151" font-family="Arial, sans-serif">AP</text>
+</svg>

--- a/public/clients/business-fashion.svg
+++ b/public/clients/business-fashion.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="200" height="100" viewBox="0 0 200 100">
+  <rect width="200" height="100" fill="#e5e7eb"/>
+  <text x="100" y="55" text-anchor="middle" font-size="40" fill="#374151" font-family="Arial, sans-serif">BF</text>
+</svg>

--- a/public/clients/elle-style.svg
+++ b/public/clients/elle-style.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="200" height="100" viewBox="0 0 200 100">
+  <rect width="200" height="100" fill="#e5e7eb"/>
+  <text x="100" y="55" text-anchor="middle" font-size="40" fill="#374151" font-family="Arial, sans-serif">ES</text>
+</svg>

--- a/public/clients/glamour-boutique.svg
+++ b/public/clients/glamour-boutique.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="200" height="100" viewBox="0 0 200 100">
+  <rect width="200" height="100" fill="#e5e7eb"/>
+  <text x="100" y="55" text-anchor="middle" font-size="40" fill="#374151" font-family="Arial, sans-serif">GB</text>
+</svg>

--- a/public/clients/kids-fashion.svg
+++ b/public/clients/kids-fashion.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="200" height="100" viewBox="0 0 200 100">
+  <rect width="200" height="100" fill="#e5e7eb"/>
+  <text x="100" y="55" text-anchor="middle" font-size="40" fill="#374151" font-family="Arial, sans-serif">KF</text>
+</svg>

--- a/public/clients/medical-uniform.svg
+++ b/public/clients/medical-uniform.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="200" height="100" viewBox="0 0 200 100">
+  <rect width="200" height="100" fill="#e5e7eb"/>
+  <text x="100" y="55" text-anchor="middle" font-size="40" fill="#374151" font-family="Arial, sans-serif">MU</text>
+</svg>

--- a/public/clients/sberbank.svg
+++ b/public/clients/sberbank.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="200" height="100" viewBox="0 0 200 100">
+  <rect width="200" height="100" fill="#e5e7eb"/>
+  <text x="100" y="55" text-anchor="middle" font-size="40" fill="#374151" font-family="Arial, sans-serif">SB</text>
+</svg>

--- a/public/clients/school-dress.svg
+++ b/public/clients/school-dress.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="200" height="100" viewBox="0 0 200 100">
+  <rect width="200" height="100" fill="#e5e7eb"/>
+  <text x="100" y="55" text-anchor="middle" font-size="40" fill="#374151" font-family="Arial, sans-serif">SD</text>
+</svg>

--- a/src/components/ClientLogos.tsx
+++ b/src/components/ClientLogos.tsx
@@ -9,18 +9,18 @@ interface Client {
 
 /**
  * Отображает карусель/сетку логотипов клиентов. В примере используются
- * изображения-заглушки с Unsplash, их следует заменить реальными логотипами.
+ * локальные SVG-логотипы, размещённые в каталоге `/public/clients`.
  */
 export default function ClientLogos() {
   const clients: Client[] = [
-    { name: 'Business Fashion', logo: 'https://source.unsplash.com/random/200x100/?business,logo,1' },
-    { name: 'Elle Style', logo: 'https://source.unsplash.com/random/200x100/?fashion,logo,2' },
-    { name: 'SberBank', logo: 'https://source.unsplash.com/random/200x100/?bank,logo,3' },
-    { name: 'ActiveWear Pro', logo: 'https://source.unsplash.com/random/200x100/?sport,logo,4' },
-    { name: 'Glamour Boutique', logo: 'https://source.unsplash.com/random/200x100/?glamour,logo,5' },
-    { name: 'Kids Fashion', logo: 'https://source.unsplash.com/random/200x100/?kids,logo,6' },
-    { name: 'Medical Uniform', logo: 'https://source.unsplash.com/random/200x100/?medical,logo,7' },
-    { name: 'School Dress', logo: 'https://source.unsplash.com/random/200x100/?school,logo,8' },
+    { name: 'Business Fashion', logo: '/clients/business-fashion.svg' },
+    { name: 'Elle Style', logo: '/clients/elle-style.svg' },
+    { name: 'SberBank', logo: '/clients/sberbank.svg' },
+    { name: 'ActiveWear Pro', logo: '/clients/activewear-pro.svg' },
+    { name: 'Glamour Boutique', logo: '/clients/glamour-boutique.svg' },
+    { name: 'Kids Fashion', logo: '/clients/kids-fashion.svg' },
+    { name: 'Medical Uniform', logo: '/clients/medical-uniform.svg' },
+    { name: 'School Dress', logo: '/clients/school-dress.svg' },
   ];
   return (
     <section id="clients" className="py-16">


### PR DESCRIPTION
## Summary
- replace unsplash placeholders with local SVG client logos
- simplify Next.js image configuration for local assets

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b1096372608325bd13bb80496fce72