### PR TITLE
feat: allow additional remote image sources

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,5 +1,11 @@
 [images]
-  remote_images = ["https://source.unsplash.com/.*", "https://images.unsplash.com/.*", "https://ext.same-assets.com/.*", "https://ugc.same-assets.com/.*"]
+  remote_images = [
+    "https://source.unsplash.com/.*",
+    "https://images.unsplash.com/.*",
+    "https://ext.same-assets.com/.*",
+    "https://ugc.same-assets.com/.*",
+    "https://picsum.photos/.*",
+  ]
 
 [build]
   command = "bun run build"
@@ -10,3 +16,4 @@
 
 [[plugins]]
   package = "@netlify/plugin-nextjs"
+

--- a/next.config.js
+++ b/next.config.js
@@ -5,6 +5,9 @@ const nextConfig = {
     domains: [
       'images.unsplash.com',
       'source.unsplash.com',
+      'ext.same-assets.com',
+      'ugc.same-assets.com',
+      'picsum.photos',
     ],
     remotePatterns: [
       {
@@ -15,6 +18,21 @@ const nextConfig = {
       {
         protocol: 'https',
         hostname: 'images.unsplash.com',
+        pathname: '/**'
+      },
+      {
+        protocol: 'https',
+        hostname: 'ext.same-assets.com',
+        pathname: '/**'
+      },
+      {
+        protocol: 'https',
+        hostname: 'ugc.same-assets.com',
+        pathname: '/**'
+      },
+      {
+        protocol: 'https',
+        hostname: 'picsum.photos',
         pathname: '/**'
       }
     ]


### PR DESCRIPTION
## Summary
- allow more remote image domains for Next.js, including ext.same-assets.com, ugc.same-assets.com, and picsum.photos
- mirror the same remote image hosts in Netlify configuration

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b1091e4d248325bfe0ca4eec910cae