### PR TITLE
feat: allow additional remote image sources

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,5 +1,11 @@
 [images]
-  remote_images = ["https://source.unsplash.com/.*", "https://images.unsplash.com/.*", "https://ext.same-assets.com/.*", "https://ugc.same-assets.com/.*"]
+  remote_images = [
+    "https://ext.same-assets.com/.*",
+    "https://images.unsplash.com/.*",
+    "https://picsum.photos/.*",
+    "https://source.unsplash.com/.*",
+    "https://ugc.same-assets.com/.*",
+  ]
 
 [build]
   command = "bun run build"
@@ -10,3 +16,4 @@
 
 [[plugins]]
   package = "@netlify/plugin-nextjs"
+

--- a/next.config.js
+++ b/next.config.js
@@ -3,20 +3,38 @@ const nextConfig = {
   images: {
     unoptimized: true,
     domains: [
+      'ext.same-assets.com',
       'images.unsplash.com',
+      'picsum.photos',
       'source.unsplash.com',
+      'ugc.same-assets.com',
     ],
     remotePatterns: [
       {
         protocol: 'https',
-        hostname: 'source.unsplash.com',
-        pathname: '/**'
+        hostname: 'ext.same-assets.com',
+        pathname: '/**',
       },
       {
         protocol: 'https',
         hostname: 'images.unsplash.com',
-        pathname: '/**'
-      }
+        pathname: '/**',
+      },
+      {
+        protocol: 'https',
+        hostname: 'picsum.photos',
+        pathname: '/**',
+      },
+      {
+        protocol: 'https',
+        hostname: 'source.unsplash.com',
+        pathname: '/**',
+      },
+      {
+        protocol: 'https',
+        hostname: 'ugc.same-assets.com',
+        pathname: '/**',
+      },
     ]
   },
 };


### PR DESCRIPTION
## Summary
- allow more remote image domains for Next.js, including ext.same-assets.com, ugc.same-assets.com, and picsum.photos
- mirror the same remote image hosts in Netlify configuration
- alphabetize remote image host lists and ensure remote patterns include trailing commas

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b1091e4d248325bfe0ca4eec910cae